### PR TITLE
Fix fqdn in install error message

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -71,7 +71,7 @@ class influxdb::install(
 
   # We can only manage repos, packages, services, etc on the node we are compiling a catalog for
   unless $influxdb_host == $facts['fqdn'] or $influxdb_host == 'localhost' {
-    fail("Unable to manage InfluxDB installation on host ${influxdb_host}")
+    fail("Unable to manage InfluxDB installation on host ${facts['fqdn']}")
   }
 
   # If we are managing the repository, set it up and install the package with a require on the repo


### PR DESCRIPTION
We cannot manage services, packages, etc on a node other than the node
which receives the catalog, so we fail compilation in this case.
However, the fqdn was previously incorrect: it should print the local,
not remote, node.