### PR TITLE
Check use_ssl is not nil

### DIFF
--- a/lib/puppet_x/puppetlabs/influxdb/influxdb.rb
+++ b/lib/puppet_x/puppetlabs/influxdb/influxdb.rb
@@ -37,7 +37,7 @@ module PuppetX
         resources.each do |resource|
           @host ||= resource[:host] ? resource[:host] : PuppetlabsInfluxdb.host
           @port ||= resource[:port] ? resource[:port] : PuppetlabsInfluxdb.port
-          @use_ssl ||= resource[:use_ssl] ? resource[:use_ssl] : PuppetlabsInfluxdb.use_ssl
+          @use_ssl ||= resource[:use_ssl] != nil ? resource[:use_ssl] : PuppetlabsInfluxdb.use_ssl
           @token ||= resource[:token]
           @token_file ||= resource[:token_file] ? resource[:token_file] : PuppetlabsInfluxdb.token_file
         end

--- a/lib/puppet_x/puppetlabs/influxdb/influxdb.rb
+++ b/lib/puppet_x/puppetlabs/influxdb/influxdb.rb
@@ -37,7 +37,7 @@ module PuppetX
         resources.each do |resource|
           @host ||= resource[:host] ? resource[:host] : PuppetlabsInfluxdb.host
           @port ||= resource[:port] ? resource[:port] : PuppetlabsInfluxdb.port
-          @use_ssl ||= resource[:use_ssl] != nil ? resource[:use_ssl] : PuppetlabsInfluxdb.use_ssl
+          @use_ssl ||= !resource[:use_ssl].nil? ? resource[:use_ssl] : PuppetlabsInfluxdb.use_ssl
           @token ||= resource[:token]
           @token_file ||= resource[:token_file] ? resource[:token_file] : PuppetlabsInfluxdb.token_file
         end


### PR DESCRIPTION
If use_ssl is nil use default otherwise use the param passed in. The old logic would always end up setting use_ssl to being true