### PR TITLE
add DSCR to influxdb2 repo 

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -85,6 +85,7 @@ class influxdb(
         }
         yumrepo {$repo_name:
           ensure   => 'present',
+          descr    => $repo_name,
           name     => $repo_name,
           baseurl  => "https://repos.influxdata.com/${dist}/\$releasever/\$basearch/stable",
           gpgkey   => 'https://repos.influxdata.com/influxdb2.key https://repos.influxdata.com/influxdb.key',


### PR DESCRIPTION
Prior to this commit any yum action resulted in the following message

Loaded plugins: fastestmirror
Repository ‘influxdb2’ is missing name in configuration, using id

this was due to the yumrepo resource which creates this being missing the dscr field, which maps to name