### PR TITLE
Use token file on disk to fetch tokens

### DIFF
--- a/lib/puppet_x/puppetlabs/influxdb/influxdb.rb
+++ b/lib/puppet_x/puppetlabs/influxdb/influxdb.rb
@@ -14,7 +14,11 @@ module PuppetX
       self.host = Facter.value('fqdn')
       self.port = 8086
       self.use_ssl = true
-      self.token_file = Dir.home + '/.influxdb_token'
+      self.token_file = if Facter.value('identity')['user'] == 'root'
+                          '/root/.influxdb_token'
+                        else
+                          "/home/#{Facter.value('identity')['user']}/.influxdb_token"
+                        end
 
       attr_accessor :telegraf_hash, :user_map, :label_hash, :auth, :bucket_hash, :dbrp_hash
 


### PR DESCRIPTION
This commit changes the retrieve_token() function to use an admin token
on disk.  This allows it to be used as a deferred function where it will
be run on agents instead of the primary server.

Also fixes an issue where Dir.home would throw an error when running via
a service.