### PR TITLE
Add get and create tests for influxdb_bucket

### DIFF
--- a/lib/puppet/provider/influxdb_bucket/influxdb_bucket.rb
+++ b/lib/puppet/provider/influxdb_bucket/influxdb_bucket.rb
@@ -2,6 +2,7 @@
 
 require 'puppet/resource_api/simple_provider'
 require_relative '../../../puppet_x/puppetlabs/influxdb/influxdb'
+require 'pry'
 
 # Implementation for performing initial setup of InfluxDB using the Resource API.
 class Puppet::Provider::InfluxdbBucket::InfluxdbBucket < Puppet::ResourceApi::SimpleProvider
@@ -92,7 +93,7 @@ class Puppet::Provider::InfluxdbBucket::InfluxdbBucket < Puppet::ResourceApi::Si
     users_to_add.each do |user|
       user_id = id_from_name(@user_map, user)
       if user_id
-        body = { 'id' => user_id }
+        body = { id: user_id }
         influx_post("/api/v2/buckets/#{bucket_id}/members", JSON.dump(body))
       else
         context.warning("Could not find user #{user}")

--- a/lib/puppet/provider/influxdb_bucket/influxdb_bucket.rb
+++ b/lib/puppet/provider/influxdb_bucket/influxdb_bucket.rb
@@ -29,7 +29,7 @@ class Puppet::Provider::InfluxdbBucket::InfluxdbBucket < Puppet::ResourceApi::Si
       response['buckets'].select { |bucket| bucket['type'] == 'user' }.reduce([]) do |memo, value|
         org_id = value['orgID']
         bucket_id = value['id']
-        dbrp = influx_get("/api/v2/dbrps/?orgID=#{org_id}", params: {})['content'].find do |d|
+        dbrp = influx_get("/api/v2/dbrps?orgID=#{org_id}", params: {})['content'].find do |d|
           d['bucketID'] == bucket_id
         end
 
@@ -63,6 +63,8 @@ class Puppet::Provider::InfluxdbBucket::InfluxdbBucket < Puppet::ResourceApi::Si
       retentionRules: should[:retention_rules],
     }
     influx_post('/api/v2/buckets', JSON.dump(body))
+
+    # Update this object's bucket cache to add the one we just created, and call update() if we need to create lables, members, or dbrps
     @bucket_hash = []
     get_bucket_info
 

--- a/lib/puppet_x/puppetlabs/influxdb/influxdb.rb
+++ b/lib/puppet_x/puppetlabs/influxdb/influxdb.rb
@@ -150,9 +150,9 @@ module PuppetX
       def get_dbrp_info
         # org is a mandatory parameter, so we have to look over each org to get all dbrps
         # get_org_info must be called before this
-        orgs = @org_hash.map { |org| org['name'] }
+        orgs = @org_hash.map { |org| org['id'] }
         orgs.each do |org|
-          dbrp = influx_get("/api/v2/dbrps?org=#{org}", params: {})
+          dbrp = influx_get("/api/v2/dbrps?orgID=#{org}", params: {})
           @dbrp_hash << dbrp
         end
       end

--- a/spec/unit/puppet/provider/influxdb_auth/influxdb_auth_spec.rb
+++ b/spec/unit/puppet/provider/influxdb_auth/influxdb_auth_spec.rb
@@ -1,0 +1,309 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'json'
+
+ensure_module_defined('Puppet::Provider::InfluxdbAuth')
+require 'puppet/provider/influxdb_auth/influxdb_auth'
+require_relative '../../../../../lib/puppet_x/puppetlabs/influxdb/influxdb'
+include PuppetX::Puppetlabs::PuppetlabsInfluxdb
+
+RSpec.describe Puppet::Provider::InfluxdbAuth::InfluxdbAuth do
+  subject(:provider) { described_class.new }
+
+  let(:context) { instance_double('Puppet::ResourceApi::BaseContext', 'context') }
+
+  let(:attrs) do
+    {
+      status: {
+        type: 'Enum[active, inactive]',
+      },
+      org: {
+        type: 'String',
+      },
+      user: {
+        type: 'Optional[String]',
+      },
+      permissions: {
+        type: 'Array[Hash]',
+      }
+    }
+  end
+
+  let(:org_response) do
+    {
+      'links' => {
+        'self' => '/api/v2/orgs'
+      },
+      'orgs' => [
+        {
+          'id' => '123',
+          'name' => 'puppetlabs',
+          'links' => {
+            'self' => '/api/v2/orgs/123',
+          },
+        },
+      ]
+    }
+  end
+
+  let(:auth_response) do
+    {
+      'links' => {
+        'self' => '/api/v2/authorizations'
+      },
+    'authorizations' => [
+      {
+        'id' => '123',
+        'user' => 'admin',
+        'token' => '321',
+        'status' => 'active',
+        'description' => 'token_1',
+        'orgID' => '123',
+        'org' => 'puppetlabs',
+        'permissions' => [
+          {
+            'action' => 'read',
+            'resource' => {
+              'type' => 'telegrafs'
+            }
+          },
+        ],
+        'links' => {
+          'self' => '/api/v2/authorizations/123',
+        }
+      },
+    ]
+    }
+  end
+
+  describe '#get' do
+    # rubocop:disable RSpec/SubjectStub
+    it 'processes resources' do
+      allow(provider).to receive(:influx_get).with('/api/v2/orgs', params: {}).and_return(org_response)
+
+      should_hash = [
+        {
+          ensure: 'present',
+          user: 'admin',
+          name: 'token_1',
+          status: 'active',
+          org: 'puppetlabs',
+          permissions: [
+            {
+              'action' => 'read',
+              'resource' => {
+                'type' => 'telegrafs'
+              }
+            },
+          ]
+        },
+      ]
+
+      allow(provider).to receive(:influx_get).with('/api/v2/authorizations', params: {}).and_return(auth_response)
+      expect(provider.get(context)).to eq should_hash
+    end
+  end
+
+  describe '#create' do
+    let(:should_hash) do
+      {
+        ensure: 'present',
+        user: 'admin',
+        name: 'token_1',
+        status: 'active',
+        org: 'puppetlabs',
+        permissions: [
+          {
+            'action' => 'read',
+            'resource' => {
+              'type' => 'telegrafs'
+            }
+          },
+        ]
+      }
+    end
+
+    it 'creates resources' do
+      post_args = {
+        orgID: 123,
+        permissions: [
+          {
+            'action' => 'read',
+            'resource' => {
+              'type' => 'telegrafs'
+            }
+          },
+        ],
+        description: 'token_1',
+        status: 'active',
+        user: 'admin'
+      }
+
+      provider.instance_variable_set('@org_hash', [{ 'name' => 'puppetlabs', 'id' => 123 }])
+
+      expect(provider).to receive(:influx_post).with('/api/v2/authorizations', JSON.dump(post_args))
+      expect(context).to receive(:debug).with("Creating '#{should_hash[:name]}' with #{should_hash.inspect}")
+
+      provider.create(context, should_hash[:name], should_hash)
+    end
+  end
+
+  describe '#update' do
+    context 'when updating status' do
+      it 'updates resources' do
+        should_hash = {
+          ensure: 'present',
+          user: 'admin',
+          name: 'token_1',
+          status: 'inactive',
+          org: 'puppetlabs',
+          permissions: [
+            {
+              'action' => 'read',
+              'resource' => {
+                'type' => 'telegrafs'
+              }
+            },
+          ]
+        }
+
+        provider.instance_variable_set(
+          '@self_hash',
+          [
+            {
+              'id' => '123',
+              'token' => 'foo',
+              'status' => 'active',
+              'description' => 'token_1',
+              'orgID' => '123',
+              'org' => 'puppetlabs',
+              'userID' => '123',
+              'user' => 'admin',
+              'permissions' => [
+                {
+                  'action' => 'read',
+                  'resource' => {
+                    'type' => 'telegrafs'
+                  }
+                },
+              ],
+              'links' => {
+                'self' => '/api/v2/authorizations/123',
+              },
+            },
+          ],
+        )
+
+        patch_args = ['/api/v2/authorizations/123', JSON.dump({ status: 'inactive', description: 'token_1' })]
+
+        expect(context).to receive(:debug).with("Updating '#{should_hash[:name]}' with #{should_hash.inspect}")
+        expect(context).not_to receive(:warning)
+        expect(provider).to receive(:influx_patch).with(*patch_args)
+
+        provider.update(context, should_hash[:name], should_hash)
+      end
+    end
+
+    context 'when updating immutable properties' do
+      it 'produces a warning' do
+        should_hash = {
+          ensure: 'present',
+          user: 'admin',
+          name: 'token_1',
+          status: 'active',
+          org: 'puppetlabs',
+          permissions: [
+            {
+              'action' => 'read',
+              'resource' => {
+                'type' => 'telegrafs'
+              }
+            },
+            {
+              'action' => 'write',
+              'resource' => {
+                'type' => 'telegrafs'
+              }
+            },
+          ]
+        }
+
+        provider.instance_variable_set(
+          '@self_hash',
+          [
+            {
+              'id' => '123',
+              'token' => 'foo',
+              'status' => 'active',
+              'description' => 'token_1',
+              'orgID' => '123',
+              'org' => 'puppetlabs',
+              'userID' => '123',
+              'user' => 'admin',
+              'permissions' => [
+                {
+                  'action' => 'read',
+                  'resource' => {
+                    'type' => 'telegrafs'
+                  }
+                },
+              ],
+              'links' => {
+                'self' => '/api/v2/authorizations/123',
+              },
+            },
+          ],
+        )
+
+        expect(context).to receive(:debug).with("Updating '#{should_hash[:name]}' with #{should_hash.inspect}")
+        expect(context).to receive(:warning).with(
+          "Unable to update properties other than 'status'.  Please delete and recreate resource with the desired properties",
+        )
+
+        provider.update(context, should_hash[:name], should_hash)
+      end
+    end
+  end
+
+  describe '#delete' do
+    it 'deletes resources' do
+      provider.instance_variable_set(
+        '@self_hash',
+        [
+          {
+            'id' => '123',
+            'token' => 'foo',
+            'status' => 'active',
+            'description' => 'token_1',
+            'orgID' => '123',
+            'org' => 'puppetlabs',
+            'userID' => '123',
+            'user' => 'admin',
+            'permissions' => [
+              {
+                'action' => 'read',
+                'resource' => {
+                  'type' => 'telegrafs'
+                }
+              },
+            ],
+            'links' => {
+              'self' => '/api/v2/authorizations/123',
+            },
+          },
+        ],
+      )
+
+      should_hash = {
+        ensure: 'absent',
+        name: 'token_1',
+      }
+
+      expect(context).to receive(:debug).with("Deleting '#{should_hash[:name]}'")
+      expect(provider).to receive(:influx_delete).with('/api/v2/authorizations/123')
+
+      provider.delete(context, should_hash[:name])
+    end
+  end
+end

--- a/spec/unit/puppet/provider/influxdb_bucket/influxdb_bucket_spec.rb
+++ b/spec/unit/puppet/provider/influxdb_bucket/influxdb_bucket_spec.rb
@@ -2,7 +2,6 @@
 
 require 'spec_helper'
 require 'json'
-require 'pry'
 
 ensure_module_defined('Puppet::Provider::InfluxdbBucket')
 require 'puppet/provider/influxdb_bucket/influxdb_bucket'
@@ -143,27 +142,30 @@ RSpec.describe Puppet::Provider::InfluxdbBucket::InfluxdbBucket do
         allow(provider).to receive(:influx_get).with('/api/v2/dbrps?orgID=123', params: {}).and_return(dbrp_response)
         allow(provider).to receive(:influx_get).with('/api/v2/buckets', params: {}).and_return(bucket_response)
 
-        should = [
+        should_hash = [
           { name: 'puppet_data',
-           ensure: 'present',
-           org: 'puppetlabs',
-           retention_rules: [{ 'type' => 'expire', 'everySeconds' => 2_592_000, 'shardGroupDurationSeconds' => 604_800 }],
-           members: [],
-           labels: [],
-           create_dbrp: true },
+            ensure: 'present',
+            org: 'puppetlabs',
+            retention_rules: [{ 'type' => 'expire', 'everySeconds' => 2_592_000, 'shardGroupDurationSeconds' => 604_800 }],
+            members: [],
+            labels: [],
+            create_dbrp: true },
         ]
 
-        expect(provider.get(context)).to eq should
+        expect(provider.get(context)).to eq should_hash
       end
     end
   end
 
   describe '#create' do
-    it 'creates resources' do
-      should = {
+    let(:should_hash) do
+      {
         name: 'puppet_data',
         org: 'puppetlabs',
       }
+    end
+
+    it 'creates resources' do
       post_args = ['/api/v2/buckets', JSON.dump({ name: 'puppet_data', orgId: 123, retentionRules: nil })]
 
       provider.instance_variable_set('@org_hash', [{ 'name' => 'puppetlabs', 'id' => 123 }])
@@ -172,8 +174,233 @@ RSpec.describe Puppet::Provider::InfluxdbBucket::InfluxdbBucket do
       allow(provider).to receive(:influx_get).with('/api/v2/buckets', params: {}).and_return(bucket_response)
       allow(provider).to receive(:influx_post).with(*post_args)
 
-      expect(context).to receive(:debug).with("Creating '/api/v2/bucket' with #{should.inspect}")
-      provider.create(context, '/api/v2/bucket', should)
+      expect(context).to receive(:debug).with("Creating '#{should_hash[:name]}' with #{should_hash.inspect}")
+      provider.create(context, should_hash[:name], should_hash)
+    end
+  end
+
+  describe '#update' do
+    context 'without users' do
+      let(:should_hash) do
+        {
+          name: 'puppet_data',
+          org: 'puppetlabs',
+          members: ['Alice', 'Bob'],
+          retention_rules: [{
+            type: 'expire',
+            everySeconds: 2_592_000,
+            shardGroupDurationSeconds: 604_800
+          }]
+        }
+      end
+
+      it 'warns about missing users' do
+        provider.instance_variable_set(
+          '@bucket_hash',
+          [
+            {
+              'name' => 'puppet_data',
+              'id' => 12_345,
+              'labels' => {
+                'links' => {
+                  'self' => '/api/v2/labels'
+                },
+                'labels' => [],
+                'members' => {
+                  'links' => {
+                    'self' => '/api/v2/buckets/12345/members'
+                  },
+                'users' => []
+                }
+              }
+            },
+          ],
+        )
+        patch_args = ['/api/v2/buckets/12345', JSON.dump({ name: should_hash[:name], retentionRules: should_hash[:retention_rules] })]
+
+        expect(context).to receive(:debug).with("Updating '#{should_hash[:name]}' with #{should_hash.inspect}")
+        expect(context).to receive(:warning).with('Could not find user Alice')
+        expect(context).to receive(:warning).with('Could not find user Bob')
+        expect(provider).to receive(:influx_patch).with(*patch_args)
+
+        provider.update(context, should_hash[:name], should_hash)
+      end
+    end
+
+    context 'with users' do
+      let(:should_hash) do
+        {
+          name: 'puppet_data',
+          org: 'puppetlabs',
+          members: ['Alice', 'Bob'],
+          retention_rules: [{
+            type: 'expire',
+            everySeconds: 2_592_000,
+            shardGroupDurationSeconds: 604_800
+          }]
+        }
+      end
+
+      it 'adds users to the bucket' do
+        provider.instance_variable_set(
+          '@bucket_hash',
+          [
+            {
+              'name' => 'puppet_data',
+              'id' => 12_345,
+              'labels' => {
+                'links' => {
+                  'self' => '/api/v2/labels'
+                },
+                'labels' => []
+              },
+              'members' => {
+                'links' => {
+                  'self' => '/api/v2/buckets/12345/members'
+                },
+                'users' => []
+              }
+            },
+          ],
+        )
+
+        provider.instance_variable_set(
+          '@user_map',
+          [
+            {
+              'links' => {
+                'self' => '/api/v2/users/321'
+              },
+              'id' => '321',
+              'name' => 'Bob',
+              'status' => 'active'
+            },
+            {
+              'links' => {
+                'self' => '/api/v2/users/4321'
+              },
+              'id' => '4321',
+              'name' => 'Alice',
+              'status' => 'active'
+            },
+          ],
+        )
+
+        patch_args = ['/api/v2/buckets/12345', JSON.dump({ name: should_hash[:name], retentionRules: should_hash[:retention_rules] })]
+
+        expect(context).to receive(:debug).with("Updating '#{should_hash[:name]}' with #{should_hash.inspect}")
+        expect(context).not_to receive(:warning)
+        expect(provider).to receive(:influx_patch).with(*patch_args)
+        expect(provider).to receive(:influx_post).with('/api/v2/buckets/12345/members', JSON.dump({ id: '4321' }))
+        expect(provider).to receive(:influx_post).with('/api/v2/buckets/12345/members', JSON.dump({ id: '321' }))
+
+        provider.update(context, should_hash[:name], should_hash)
+      end
+    end
+
+    context 'without labels' do
+      let(:should_hash) do
+        {
+          name: 'puppet_data',
+          org: 'puppetlabs',
+          labels: ['label_1', 'label_2']
+        }
+      end
+
+      it 'warns about missing labels' do
+        provider.instance_variable_set(
+          '@bucket_hash',
+          [
+            {
+              'name' => 'puppet_data',
+              'id' => 12_345,
+              'labels' => {
+                'links' => {
+                  'self' => '/api/v2/labels'
+                },
+                'labels' => []
+              },
+              'members' => {
+                'links' => {
+                  'self' => '/api/v2/buckets/12345/members'
+                },
+                'users' => []
+              }
+            },
+          ],
+        )
+
+        patch_args = ['/api/v2/buckets/12345', JSON.dump({ name: should_hash[:name], retentionRules: should_hash[:retention_rules] })]
+
+        expect(context).to receive(:debug).with("Updating '#{should_hash[:name]}' with #{should_hash.inspect}")
+        expect(context).to receive(:warning).with('Could not find label label_1')
+        expect(context).to receive(:warning).with('Could not find label label_2')
+        expect(provider).to receive(:influx_patch).with(*patch_args)
+        # expect(provider).to receive(:influx_post).with('/api/v2/buckets/12345/members', JSON.dump({id: '4321'}))
+        # expect(provider).to receive(:influx_post).with('/api/v2/buckets/12345/members', JSON.dump({id: '321'}))
+
+        provider.update(context, should_hash[:name], should_hash)
+      end
+    end
+
+    context 'with labels' do
+      let(:should_hash) do
+        {
+          name: 'puppet_data',
+          org: 'puppetlabs',
+          labels: ['label_1', 'label_2']
+        }
+      end
+
+      it 'adds labels to the bucket' do
+        provider.instance_variable_set(
+          '@bucket_hash',
+          [
+            {
+              'name' => 'puppet_data',
+              'id' => 12_345,
+              'labels' => {
+                'links' => {
+                  'self' => '/api/v2/labels'
+                },
+                'labels' => []
+              },
+              'members' => {
+                'links' => {
+                  'self' => '/api/v2/buckets/12345/members'
+                },
+                'users' => []
+              }
+            },
+          ],
+        )
+
+        provider.instance_variable_set(
+          '@label_hash',
+          [
+            {
+              'id' => '321',
+              'orgID' => '123',
+              'name' => 'label_1'
+            },
+            {
+              'id' => '3210',
+              'orgID' => '123',
+              'name' => 'label_2'
+            },
+          ],
+        )
+
+        patch_args = ['/api/v2/buckets/12345', JSON.dump({ name: should_hash[:name], retentionRules: should_hash[:retention_rules] })]
+
+        expect(context).to receive(:debug).with("Updating '#{should_hash[:name]}' with #{should_hash.inspect}")
+        expect(context).not_to receive(:warning)
+        expect(provider).to receive(:influx_patch).with(*patch_args)
+        expect(provider).to receive(:influx_post).with('/api/v2/buckets/12345/labels', JSON.dump({ labelID: '321' }))
+        expect(provider).to receive(:influx_post).with('/api/v2/buckets/12345/labels', JSON.dump({ labelID: '3210' }))
+
+        provider.update(context, should_hash[:name], should_hash)
+      end
     end
   end
 end

--- a/spec/unit/puppet/provider/influxdb_bucket/influxdb_bucket_spec.rb
+++ b/spec/unit/puppet/provider/influxdb_bucket/influxdb_bucket_spec.rb
@@ -1,0 +1,179 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'json'
+require 'pry'
+
+ensure_module_defined('Puppet::Provider::InfluxdbBucket')
+require 'puppet/provider/influxdb_bucket/influxdb_bucket'
+require_relative '../../../../../lib/puppet_x/puppetlabs/influxdb/influxdb'
+include PuppetX::Puppetlabs::PuppetlabsInfluxdb
+
+RSpec.describe Puppet::Provider::InfluxdbBucket::InfluxdbBucket do
+  subject(:provider) { described_class.new }
+
+  let(:context) { instance_double('Puppet::ResourceApi::BaseContext', 'context') }
+
+  let(:attrs) do
+    {
+      name: {
+        type: 'String',
+      },
+      labels: {
+        type: 'Optional[Array[String]]',
+      },
+      org: {
+        type: 'String',
+      },
+      retention_rules: {
+        type: 'Array',
+      },
+      members: {
+        type: 'Optional[Array[String]]',
+      },
+      create_dbrp: {
+        type: 'Boolean',
+      }
+    }
+  end
+
+  let(:bucket_response) do
+    {
+      'links' => {
+        'self' => '/api/v2/buckets?descending=false&limit=20&offset=0'
+      },
+      'buckets' => [
+        {
+          'id' => '12345',
+          'orgID' => '123',
+          'type' => 'user',
+          'name' => 'puppet_data',
+          'links' => {
+            'self' => '/api/v2/buckets/12345',
+          },
+          'retentionRules' => [
+            {
+              'type' => 'expire',
+              'everySeconds' => 2_592_000,
+              'shardGroupDurationSeconds' => 604_800
+            },
+          ],
+          'labels' => { 'links' => { 'self' => '/api/v2/labels' }, 'labels' => [] }
+        },
+      ]
+    }
+  end
+
+  let(:org_response) do
+    {
+      'links' => {
+        'self' => '/api/v2/orgs'
+      },
+      'orgs' => [
+        {
+          'id' => '123',
+          'name' => 'puppetlabs',
+          'links' => {
+            'self' => '/api/v2/orgs/123',
+          },
+        },
+      ]
+    }
+  end
+
+  let(:label_response) do
+    {
+      'links' => {
+        'self' => '/api/v2/labels'
+      },
+      'labels' => [
+        {
+          'id' => '1234',
+          'orgID' => '123',
+          'name' => 'puppetlabs/influxdb',
+          'links' => {
+            'self' => '/api/v2/labels/1234',
+          },
+        },
+      ]
+    }
+  end
+
+  let(:user_response) do
+    {
+      'links' => {
+        'self' => '/api/v2/users'
+      },
+      'users' => [
+        {
+          'links' => {
+            'self' => '/api/v2/users/123456'
+          },
+          'id' => '123456',
+          'name' => 'admin',
+          'status' => 'active'
+        },
+      ]
+    }
+  end
+
+  let(:dbrp_response) do
+    {
+      'content' => [
+        {
+          'id' => '1234567',
+          'database' => 'puppet_data',
+          'retention_policy' => 'Forever',
+          'default' => true,
+          'orgID' => '123',
+          'bucketID' => '12345'
+        },
+      ]
+    }
+  end
+
+  describe '#get' do
+    # You must create a bucket during initial setup, so there will always be one returned by the provider
+    context 'with bucket resources' do
+      # rubocop:disable RSpec/SubjectStub
+      it 'processes resources' do
+        allow(provider).to receive(:influx_get).with('/api/v2/orgs', params: {}).and_return(org_response)
+        allow(provider).to receive(:influx_get).with('/api/v2/labels', params: {}).and_return(label_response)
+        allow(provider).to receive(:influx_get).with('/api/v2/users', params: {}).and_return(label_response)
+        allow(provider).to receive(:influx_get).with('/api/v2/dbrps?orgID=123', params: {}).and_return(dbrp_response)
+        allow(provider).to receive(:influx_get).with('/api/v2/buckets', params: {}).and_return(bucket_response)
+
+        should = [
+          { name: 'puppet_data',
+           ensure: 'present',
+           org: 'puppetlabs',
+           retention_rules: [{ 'type' => 'expire', 'everySeconds' => 2_592_000, 'shardGroupDurationSeconds' => 604_800 }],
+           members: [],
+           labels: [],
+           create_dbrp: true },
+        ]
+
+        expect(provider.get(context)).to eq should
+      end
+    end
+  end
+
+  describe '#create' do
+    it 'creates resources' do
+      should = {
+        name: 'puppet_data',
+        org: 'puppetlabs',
+      }
+      post_args = ['/api/v2/buckets', JSON.dump({ name: 'puppet_data', orgId: 123, retentionRules: nil })]
+
+      provider.instance_variable_set('@org_hash', [{ 'name' => 'puppetlabs', 'id' => 123 }])
+      provider.instance_variable_set('@bucket_hash', [{ 'name' => 'puppet_data', 'id' => 12_345 }])
+
+      allow(provider).to receive(:influx_get).with('/api/v2/buckets', params: {}).and_return(bucket_response)
+      allow(provider).to receive(:influx_post).with(*post_args)
+
+      expect(context).to receive(:debug).with("Creating '/api/v2/bucket' with #{should.inspect}")
+      provider.create(context, '/api/v2/bucket', should)
+    end
+  end
+end


### PR DESCRIPTION
This commit adds spec tests for get() and create() methods for the
influxdb_bucket provider.