### PR TITLE
Rescue exception in retrieve_token function

### DIFF
--- a/lib/puppet/functions/influxdb/retrieve_token.rb
+++ b/lib/puppet/functions/influxdb/retrieve_token.rb
@@ -10,18 +10,23 @@ Puppet::Functions.create_function(:'influxdb::retrieve_token') do
 
   def retrieve_token(uri, token_name, admin_token_file)
     return unless File.file?(admin_token_file)
-    admin_token = File.read(admin_token_file)
+    begin
+      admin_token = File.read(admin_token_file)
 
-    client = Puppet.runtime[:http]
-    response = client.get(URI(uri + '/api/v2/authorizations'),
-                           headers: { 'Authorization' => "Token #{admin_token}" })
+      client = Puppet.runtime[:http]
+      response = client.get(URI(uri + '/api/v2/authorizations'),
+                             headers: { 'Authorization' => "Token #{admin_token}" })
 
-    if response.success?
-      body = JSON.parse(response.body)
-      token = body['authorizations'].find { |auth| auth['description'] == token_name }
-      token ? token['token'] : nil
-    else
-      puts response.body
+      if response.success?
+        body = JSON.parse(response.body)
+        token = body['authorizations'].find { |auth| auth['description'] == token_name }
+        token ? token['token'] : nil
+      else
+        Puppet.err("Unable to retrieve #{token_name}": response.body)
+        nil
+      end
+    rescue StandardError => e
+      Puppet.err("Unable to retrieve #{token_name}": e.message)
       nil
     end
   end


### PR DESCRIPTION
This commit rescues StandardError and raises an error with the message
using Puppet.err.  It also adds the response body to the error in case
of an http error code.