### PR TITLE
when certs are symlinks bolt complained, looking for puppet x509 stuff

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -7,11 +7,13 @@ fixtures:
     yumrepo: "puppetlabs/yumrepo_core"
     apt: "puppetlabs/apt"
   repositories:
-    facts: 'https://github.com/puppetlabs/puppetlabs-facts'
-    puppet_agent: 'https://github.com/puppetlabs/puppetlabs-puppet_agent'
-    provision: 'https://github.com/puppetlabs/provision'
     bootstrap: 'https://github.com/puppetlabs/puppetlabs-bootstrap'
+    deploy_pe: 'https://github.com/jarretlavallee/puppet-deploy_pe'
+    facts: 'https://github.com/puppetlabs/puppetlabs-facts'
+    provision: 'https://github.com/puppetlabs/provision'
+    puppet_agent: 'https://github.com/puppetlabs/puppetlabs-puppet_agent'
     puppet_conf: 'https://github.com/puppetlabs/puppetlabs-puppet_conf'
     ruby_task_helper: 'https://git@github.com/puppetlabs/puppetlabs-ruby_task_helper'
     stdlib: 'https://github.com/puppetlabs/puppetlabs-stdlib'
-    deploy_pe: 'https://github.com/jarretlavallee/puppet-deploy_pe'
+  symlinks:
+    influxdb: "#{source_dir}" # for custom type(s)

--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ InfluxDB resources are managed by the various types and providers. Because we ne
 * use_ssl - true
 * token (optional)
 
-Specifying a `token` in `Sensitive[String]` format is optional, but recommended. See [Beggining with Influxdb](#beginning-with-influxdb) for more info.
+Specifying a `token` in `Sensitive[String]` format is optional, but recommended. See [Beginning with Influxdb](#beginning-with-influxdb) for more info.
 
 Note that you are *not* able to use multiple combinations of these options in a given catalog.  Each provider class will set these values when first instantiated and will use the first value that it finds.  Therefore, it is best to use resource defaults for these parameters in your manifest, e.g.
 
-```
+```puppet
 class my_profile::my_class(
   Sensitive[String] $my_token,
 ){
@@ -60,7 +60,7 @@ See [Usage](#usage) for more information about these use cases.
 
 The easiest way to get started using this module is by including the `influxdb` class to install and perform initial setup of the application.
 
-```
+```puppet
 include influxdb
 ```
 
@@ -89,14 +89,14 @@ Note that the admin user and password can be set prior to initial setup, but can
 
 For example, to use a different initial organization and bucket, set the parameters in hiera:
 
-```
+```puppet
 influxdb::initial_org: 'my_org'
 influxdb::initial_bucket: 'my_bucket'
 ```
 
 Or use a class-like declaration
 
-```
+```puppet
 class {'influxdb':
   initial_org    => 'my_org',
   initial_bucket => 'my_bucket',
@@ -107,7 +107,7 @@ class {'influxdb':
 
 For managing InfluxDB resources, this module provides several types and providers that use the [InfluxDB 2.0 api](https://docs.influxdata.com/influxdb/v2.1/api/).  As mentioned in [What influxdb affects](#what-influxdb-affects), the resources accept parameters to determine how to connect to the host which must be unique per resource type.  For example, to create an organization and bucket and specify a token and non-standard port:
 
-```
+```puppet
 class my_profile::my_class(
   Sensitive[String] $token,
 ){
@@ -130,7 +130,7 @@ class my_profile::my_class(
 
 Resource defaults are also a good option:
 
-```
+```puppet
 Influxdb_org {
   token => $token,
   port  => 1234,
@@ -146,7 +146,7 @@ Note that the `influxdb_bucket` will produce a warning for each specified label 
 
 If InfluxDB is running locally and there is an admin token saved at `~/.influxdb_token`, it will be used in API calls if the `token` parameter is unset.  However, it is recommended to set the token in hiera as an eyaml-encrypted string.  For example:
 
-```
+```yaml
 influxdb::token: '<eyaml_string>'
 lookup_options:
    influxdb::token:
@@ -161,7 +161,7 @@ For more complex resource management, here is an example of:
 
 Hiera data:
 
-```
+```yaml
 profile::buckets:
   - 'bucket1'
   - 'bucket2'
@@ -170,7 +170,7 @@ profile::buckets:
 
 Puppet code:
 
-```
+```puppet
 class my_profile::my_class{
   $buckets = lookup('profile::buckets')
   $bucket_hash = $buckets.reduce({}) |$memo, $bucket| {

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -6,3 +6,4 @@ influxdb::initial_bucket: 'puppet_data'
 influxdb::repo_gpg_key_id: '05CE15085FC09D18E99EFB22684A14CF2582E0C5'
 influxdb::repo_gpg_key_url: 'https://repos.influxdata.com/influxdb2.key https://repos.influxdata.com/influxdb.key'
 influxdb::manage_repo: false
+influxdb::profile::toml::version: '2.1.1'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -145,6 +145,7 @@ class influxdb (
       owner  => 'root',
       group  => 'root',
     }
+
     file { '/var/lib/influxdb':
       ensure => directory,
       owner  => 'influxdb',
@@ -155,6 +156,7 @@ class influxdb (
       'Debian' => '/etc/default',
       default  => '/etc/sysconfig',
     }
+
     file { '/etc/systemd/system/influxdb.service':
       ensure   => file,
       content  => epp('influxdb/influxdb_service.epp',
@@ -175,6 +177,7 @@ class influxdb (
     group { 'influxdb':
       ensure => present,
     }
+
     user { 'influxdb':
       ensure => present,
       gid    => 'influxdb',
@@ -198,7 +201,7 @@ class influxdb (
     }
   }
 
-  service { 'influxdb':
+  service {'influxdb':
     ensure => running,
     enable => true,
   }
@@ -211,12 +214,14 @@ class influxdb (
         links  => 'follow',
         notify => Service['influxdb'],
       }
+
       file { '/etc/influxdb/key.pem':
         ensure => file,
         source => "file:///${ssl_key_file}",
         links  => 'follow',
         notify => Service['influxdb'],
       }
+
       file { '/etc/influxdb/ca.pem':
         ensure => file,
         source => "file:///${ssl_ca_file}",
@@ -230,6 +235,7 @@ class influxdb (
       owner  => 'influxdb',
       notify => Service['influxdb'],
     }
+
     file { '/etc/systemd/system/influxdb.service.d/override.conf':
       ensure  => file,
       #TODO: epp necessary?

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -195,7 +195,7 @@ class influxdb (
 
   # Otherwise, assume we have a source for the package
   else {
-    package { 'influxdb2':
+    package {'influxdb2':
       ensure => installed,
       before => $package_before,
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -195,13 +195,13 @@ class influxdb (
 
   # Otherwise, assume we have a source for the package
   else {
-    package {'influxdb2':
+    package { 'influxdb2':
       ensure => installed,
       before => $package_before,
     }
   }
 
-  service {'influxdb':
+  service { 'influxdb':
     ensure => running,
     enable => true,
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -30,8 +30,6 @@
 #   CA certificate issued by the CA which signed the certificate specified by $ssl_cert_file.  Defaults to the Puppet CA.
 # @param host
 #   fqdn of the host running InfluxDB.  Defaults to the fqdn of the local machine
-# @param port
-#   port of the InfluxDB Service. Defaults to 8086
 # @param initial_org
 #   Name of the initial organization to use during initial setup.  Defaults to puppetlabs
 # @param initial_bucket
@@ -52,7 +50,6 @@
 class influxdb (
   # Provided by module data
   String  $host,
-  Integer $port,
   String  $initial_org,
   String  $initial_bucket,
   String  $repo_gpg_key_id,
@@ -75,9 +72,9 @@ class influxdb (
   String  $admin_user = 'admin',
   Sensitive[String[1]] $admin_pass = Sensitive('puppetlabs'),
   String  $token_file = $facts['identity']['user'] ? {
-                                      'root'  => '/root/.influxdb_token',
+    'root'  => '/root/.influxdb_token',
     default => "/home/${facts['identity']['user']}/.influxdb_token" #lint:ignore:parameter_documentation
-                                    },
+  },
 ) {
   # We can only manage repos, packages, services, etc on the node we are compiling a catalog for
   unless $host == $facts['networking']['fqdn'] or $host == 'localhost' {
@@ -135,7 +132,7 @@ class influxdb (
       }
     }
 
-    package {'influxdb2':
+    package { 'influxdb2':
       ensure  => $version,
       require => $package_require,
       before  => $package_before,
@@ -211,16 +208,19 @@ class influxdb (
       file { '/etc/influxdb/cert.pem':
         ensure => file,
         source => "file:///${ssl_cert_file}",
+        links  => 'follow',
         notify => Service['influxdb'],
       }
       file { '/etc/influxdb/key.pem':
         ensure => file,
         source => "file:///${ssl_key_file}",
+        links  => 'follow',
         notify => Service['influxdb'],
       }
       file { '/etc/influxdb/ca.pem':
         ensure => file,
         source => "file:///${ssl_ca_file}",
+        links  => 'follow',
         notify => Service['influxdb'],
       }
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,4 +1,5 @@
 # @summary Installs, configures, and performs initial setup of InfluxDB 2.x
+#
 # @example Basic usage
 #   include influxdb
 #
@@ -6,6 +7,7 @@
 #     initial_org => 'my_org',
 #     initial_bucket => 'my_bucket',
 #   }
+#
 # @param manage_repo
 #   Whether to manage a repository to provide InfluxDB packages.  Defaults to true
 # @param manage_setup

--- a/manifests/profile/toml.pp
+++ b/manifests/profile/toml.pp
@@ -1,9 +1,16 @@
 # @summary Installs the toml-rb gem inside Puppet server
+#
+# @param version
+#   Specific version of toml-rb gem
+#
 # @example Basic usage
 #   include influxdb::profile::toml
+#
+
+#
 class influxdb::profile::toml (
-  String $version = '2.1.1',
-){
+  String $version,
+) {
   $service_name = $facts['pe_server_version'] ? {
     undef   => 'puppetserver',
     default => 'pe-puppetserver',


### PR DESCRIPTION
various typos in README
unused param (port)
follow links to certificate(s)