### PR TITLE
(Sup 3678) Fix use_ssl parameter

### DIFF
--- a/lib/puppet/provider/influxdb_auth/influxdb_auth.rb
+++ b/lib/puppet/provider/influxdb_auth/influxdb_auth.rb
@@ -31,6 +31,7 @@ class Puppet::Provider::InfluxdbAuth::InfluxdbAuth < Puppet::ResourceApi::Simple
           {
             name: value['description'],
             ensure: 'present',
+            use_ssl: @use_ssl,
             permissions: value['permissions'],
             status: value['status'],
             user: value['user'],

--- a/lib/puppet/provider/influxdb_bucket/influxdb_bucket.rb
+++ b/lib/puppet/provider/influxdb_bucket/influxdb_bucket.rb
@@ -41,6 +41,7 @@ class Puppet::Provider::InfluxdbBucket::InfluxdbBucket < Puppet::ResourceApi::Si
           {
             name: value['name'],
             ensure: 'present',
+            use_ssl: @use_ssl,
             org: name_from_id(@org_hash, value['orgID']),
             retention_rules: value['retentionRules'],
             members: bucket_members ? bucket_members.map { |member| member['name'] } : [],

--- a/lib/puppet/provider/influxdb_dbrp/influxdb_dbrp.rb
+++ b/lib/puppet/provider/influxdb_dbrp/influxdb_dbrp.rb
@@ -28,6 +28,7 @@ class Puppet::Provider::InfluxdbDbrp::InfluxdbDbrp < Puppet::ResourceApi::Simple
       memo + [
         {
           ensure: 'present',
+          use_ssl: @use_ssl,
           name: value['database'],
           org: name_from_id(@org_hash, value['orgID']),
           bucket: name_from_id(@bucket_hash, value['bucketID']),

--- a/lib/puppet/provider/influxdb_label/influxdb_label.rb
+++ b/lib/puppet/provider/influxdb_label/influxdb_label.rb
@@ -26,6 +26,7 @@ class Puppet::Provider::InfluxdbLabel::InfluxdbLabel < Puppet::ResourceApi::Simp
       response['labels'].map do |label|
         {
           name: label['name'],
+          use_ssl: @use_ssl,
           ensure: 'present',
           org: name_from_id(@org_hash, label['orgID']),
           properties: label['properties'],

--- a/lib/puppet/provider/influxdb_org/influxdb_org.rb
+++ b/lib/puppet/provider/influxdb_org/influxdb_org.rb
@@ -28,6 +28,7 @@ class Puppet::Provider::InfluxdbOrg::InfluxdbOrg < Puppet::ResourceApi::SimplePr
         memo + [
           {
             name: value['name'],
+            use_ssl: @use_ssl,
             ensure: 'present',
             members: org_members ? org_members.map { |member| member['name'] } : [],
             description: value['description']

--- a/lib/puppet/provider/influxdb_setup/influxdb_setup.rb
+++ b/lib/puppet/provider/influxdb_setup/influxdb_setup.rb
@@ -21,6 +21,7 @@ class Puppet::Provider::InfluxdbSetup::InfluxdbSetup < Puppet::ResourceApi::Simp
     [
       {
         name: @host,
+        use_ssl: @use_ssl,
         ensure: response['allowed'] == true ? 'absent' : 'present',
       },
     ]

--- a/lib/puppet/provider/influxdb_user/influxdb_user.rb
+++ b/lib/puppet/provider/influxdb_user/influxdb_user.rb
@@ -28,6 +28,7 @@ class Puppet::Provider::InfluxdbUser::InfluxdbUser < Puppet::ResourceApi::Simple
         memo + [
           {
             name: name,
+            use_ssl: @use_ssl,
             ensure: 'present',
             status: value['status'],
           },

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -247,6 +247,7 @@ class influxdb (
   if $manage_setup {
     influxdb_setup { $host:
       ensure     => 'present',
+      use_ssl    => $use_ssl,
       token_file => $token_file,
       bucket     => $initial_bucket,
       org        => $initial_org,


### PR DESCRIPTION
Prior to this commit, the state of the resources did not include the
use_ssl option.  This would cause them to default to using ssl because
this is the default from the shared library.
