### PR TITLE
Change apt dependency to >= 8.0.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -12,7 +12,7 @@
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">= 9.0.0 <10.0.0"
+      "version_requirement": ">= 8.0.0 <10.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
This fixes a dependency conflict with puppet/telegraf, which requires
>= 2.0.0 < 9.0.0