### PR TITLE
(SUP-3705) Require Apt::Update class on Ubuntu

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -130,7 +130,10 @@ class influxdb (
             'source' => $repo_gpg_key_url,
           },
         }
-        $package_require = Apt::Source[$repo_name]
+        $package_require = [
+          Apt::Source[$repo_name],
+          Class['Apt::Update']
+        ]
       }
       default: {
         notify { 'influxdb_repo_warn':


### PR DESCRIPTION
Prior to this commit, installing the influxdb2 package may happen before apt's sources were updated, resulting in an error.  This commit adds the Apt::Update class as a requirement so that the sources are refreshed first.