### PR TITLE
Remove toml_rb_gem fact

### DIFF
--- a/lib/facter/toml_rb_gem.rb
+++ b/lib/facter/toml_rb_gem.rb
@@ -1,7 +1,0 @@
-Facter.add(:toml_rb_gem) do
-  confine kernel: 'Linux'
-
-  setcode do
-    { gem_installed: File.directory?('/opt/puppetlabs/server/data/puppetserver/jruby-gems/gems/toml-rb-2.1.1/') }
-  end
-end


### PR DESCRIPTION
The idea behind this fact was to check the installed version of the toml-rb gem, but it ended up going unused.