### PR TITLE
Permit short hostnames to be used

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -80,7 +80,7 @@ class influxdb (
                                     },
 ) {
   # We can only manage repos, packages, services, etc on the node we are compiling a catalog for
-  unless $host == $facts['networking']['fqdn'] or $host == 'localhost' {
+  unless $host == $facts['networking']['fqdn'] or $host == $facts['networking']['hostname'] or $host == 'localhost' {
     fail(
       @("MSG")
         Unable to manage InfluxDB installation on host: ${host}.


### PR DESCRIPTION
In addition to FQDN and 'localhost', permit the short hostname to be used in the InfluxDB host parameter.