### PR TITLE
Update influxdb repo key

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -3,6 +3,6 @@ influxdb::host: "%{facts.fqdn}"
 influxdb::port: 8086
 influxdb::initial_org: 'puppetlabs'
 influxdb::initial_bucket: 'puppet_data'
-influxdb::repo_gpg_key_id: '05CE15085FC09D18E99EFB22684A14CF2582E0C5'
-influxdb::repo_gpg_key_url: 'https://repos.influxdata.com/influxdb2.key https://repos.influxdata.com/influxdb.key'
+influxdb::repo_gpg_key_id: '9D539D90D3328DC7D6C8D3B9D8FF8E1F7DF8B07E'
+influxdb::repo_gpg_key_url: 'https://repos.influxdata.com/influxdata-archive_compat.key'
 influxdb::manage_repo: false

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -75,7 +75,7 @@ describe 'influxdb' do
           descr: 'influxdb2',
           name: 'influxdb2',
           baseurl: 'https://repos.influxdata.com/rhel/$releasever/$basearch/stable',
-          gpgkey: 'https://repos.influxdata.com/influxdb2.key https://repos.influxdata.com/influxdb.key',
+          gpgkey: 'https://repos.influxdata.com/influxdata-archive_compat.key',
           enabled: '1',
           gpgcheck: '1',
           target: '/etc/yum.repos.d/influxdb2.repo',


### PR DESCRIPTION
The repo key has been changed: https://www.influxdata.com/blog/linux-package-signing-key-rotation/

https://portal.influxdata.com/downloads/


```
[...]
Get:6 https://repos.influxdata.com/ubuntu focal InRelease [7.019 B]            
Err:6 https://repos.influxdata.com/ubuntu focal InRelease                      
  The following signatures couldn't be verified because the public key is not available: NO_PUBKEY D8FF8E1F7DF8B07E
Hit:7 https://packagecloud.io/sensu/stable/ubuntu focal InRelease
Reading package lists... Done
W: GPG error: https://repos.influxdata.com/ubuntu focal InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY D8FF8E1F7DF8B07E
E: The repository 'https://repos.influxdata.com/ubuntu focal InRelease' is no longer signed.
N: Updating from such a repository can't be done securely, and is therefore disabled by default.
N: See apt-secure(8) manpage for repository creation and user configuration details.

```