### PR TITLE
(SUP-3968) Support paginated api responses

### DIFF
--- a/lib/puppet/provider/influxdb_auth/influxdb_auth.rb
+++ b/lib/puppet/provider/influxdb_auth/influxdb_auth.rb
@@ -16,6 +16,10 @@ class Puppet::Provider::InfluxdbAuth::InfluxdbAuth < Puppet::ResourceApi::Simple
   def canonicalize(_context, resources)
     init_attrs(resources)
     resources
+  rescue StandardError => e
+    context.err("Error canonicalizing resources: #{e.message}")
+    context.err(e.backtrace)
+    nil
   end
 
   def get(_context)
@@ -46,6 +50,10 @@ class Puppet::Provider::InfluxdbAuth::InfluxdbAuth < Puppet::ResourceApi::Simple
     else
       []
     end
+  rescue StandardError => e
+    context.err("Error getting auth state: #{e.message}")
+    context.err(e.backtrace)
+    nil
   end
 
   def create(context, name, should)
@@ -60,6 +68,10 @@ class Puppet::Provider::InfluxdbAuth::InfluxdbAuth < Puppet::ResourceApi::Simple
     }
 
     influx_post('/api/v2/authorizations', JSON.dump(body))
+  rescue StandardError => e
+    context.err("Error creating auth state: #{e.message}")
+    context.err(e.backtrace)
+    nil
   end
 
   def update(context, name, should)
@@ -78,6 +90,10 @@ class Puppet::Provider::InfluxdbAuth::InfluxdbAuth < Puppet::ResourceApi::Simple
 
       influx_patch("/api/v2/authorizations/#{auth_id}", JSON.dump(body))
     end
+  rescue StandardError => e
+    context.err("Error updating auth state: #{e.message}")
+    context.err(e.backtrace)
+    nil
   end
 
   def delete(context, name)
@@ -86,4 +102,8 @@ class Puppet::Provider::InfluxdbAuth::InfluxdbAuth < Puppet::ResourceApi::Simple
     token_id = @self_hash.find { |auth| auth['description'] == name }.dig('id')
     influx_delete("/api/v2/authorizations/#{token_id}")
   end
+  rescue StandardError => e
+    context.err("Error deleting auth state: #{e.message}")
+    context.err(e.backtrace)
+    nil
 end

--- a/lib/puppet/provider/influxdb_auth/influxdb_auth.rb
+++ b/lib/puppet/provider/influxdb_auth/influxdb_auth.rb
@@ -34,7 +34,7 @@ class Puppet::Provider::InfluxdbAuth::InfluxdbAuth < Puppet::ResourceApi::Simple
       next unless r['authorizations']
 
       r['authorizations'].each do |auth|
-        _val = {
+        val = {
           name: auth['description'],
           ensure: 'present',
           use_ssl: @use_ssl,
@@ -48,8 +48,8 @@ class Puppet::Provider::InfluxdbAuth::InfluxdbAuth < Puppet::ResourceApi::Simple
           org: auth['org'],
         }
 
-      @self_hash << auth
-      ret << _val
+        @self_hash << auth
+        ret << val
       end
     end
     ret
@@ -105,8 +105,8 @@ class Puppet::Provider::InfluxdbAuth::InfluxdbAuth < Puppet::ResourceApi::Simple
     token_id = @self_hash.find { |auth| auth['description'] == name }.dig('id')
     influx_delete("/api/v2/authorizations/#{token_id}")
   end
-  rescue StandardError => e
-    context.err("Error deleting auth state: #{e.message}")
-    context.err(e.backtrace)
-    nil
+rescue StandardError => e
+  context.err("Error deleting auth state: #{e.message}")
+  context.err(e.backtrace)
+  nil
 end

--- a/lib/puppet/provider/influxdb_auth/influxdb_auth.rb
+++ b/lib/puppet/provider/influxdb_auth/influxdb_auth.rb
@@ -23,6 +23,9 @@ class Puppet::Provider::InfluxdbAuth::InfluxdbAuth < Puppet::ResourceApi::Simple
   end
 
   def get(_context)
+    init_auth if @auth.empty?
+    get_org_info if @org_hash.empty?
+
     init_auth
     get_org_info
 

--- a/lib/puppet/provider/influxdb_bucket/influxdb_bucket.rb
+++ b/lib/puppet/provider/influxdb_bucket/influxdb_bucket.rb
@@ -14,6 +14,10 @@ class Puppet::Provider::InfluxdbBucket::InfluxdbBucket < Puppet::ResourceApi::Si
   def canonicalize(_context, resources)
     init_attrs(resources)
     resources
+  rescue StandardError => e
+    context.err("Error canonicalizing resources: #{e.message}")
+    context.err(e.backtrace)
+    nil
   end
 
   def get(_context)
@@ -57,6 +61,10 @@ class Puppet::Provider::InfluxdbBucket::InfluxdbBucket < Puppet::ResourceApi::Si
     else
       []
     end
+  rescue StandardError => e
+    context.err("Error getting bucket state: #{e.message}")
+    context.err(e.backtrace)
+    nil
   end
 
   def create(context, name, should)
@@ -74,6 +82,10 @@ class Puppet::Provider::InfluxdbBucket::InfluxdbBucket < Puppet::ResourceApi::Si
     get_bucket_info
 
     update(context, name, should) if should[:labels] || should[:members] || should[:create_dbrp]
+  rescue StandardError => e
+    context.err("Error creating bucket: #{e.message}")
+    context.err(e.backtrace)
+    nil
   end
 
   def update(context, name, should)
@@ -141,6 +153,10 @@ class Puppet::Provider::InfluxdbBucket::InfluxdbBucket < Puppet::ResourceApi::Si
       retentionRules: should[:retention_rules],
     }
     influx_patch("/api/v2/buckets/#{bucket_id}", JSON.dump(body))
+  rescue StandardError => e
+    context.err("Error updating buckets: #{e.message}")
+    context.err(e.backtrace)
+    nil
   end
 
   def delete(context, name)
@@ -148,4 +164,8 @@ class Puppet::Provider::InfluxdbBucket::InfluxdbBucket < Puppet::ResourceApi::Si
     id = id_from_name(@bucket_hash, name)
     influx_delete("/api/v2/buckets/#{id}")
   end
+  rescue StandardError => e
+    context.err("Error deleting bucket state: #{e.message}")
+    context.err(e.backtrace)
+    nil
 end

--- a/lib/puppet/provider/influxdb_bucket/influxdb_bucket.rb
+++ b/lib/puppet/provider/influxdb_bucket/influxdb_bucket.rb
@@ -57,6 +57,13 @@ class Puppet::Provider::InfluxdbBucket::InfluxdbBucket < Puppet::ResourceApi::Si
             create_dbrp: dbrp ? true : false,
           },
         ]
+    init_auth if @auth.empty?
+    get_org_info if @org_hash.empty?
+    get_bucket_info if @bucket_hash.empty?
+    get_label_info if @label_hash.empty?
+    get_dbrp_info if @dbrp_hash.empty?
+    get_user_info if @user_map.empty?
+
       end
     else
       []

--- a/lib/puppet/provider/influxdb_bucket/influxdb_bucket.rb
+++ b/lib/puppet/provider/influxdb_bucket/influxdb_bucket.rb
@@ -33,7 +33,7 @@ class Puppet::Provider::InfluxdbBucket::InfluxdbBucket < Puppet::ResourceApi::Si
     response.each do |r|
       next unless r['buckets']
       r['buckets'].select { |bucket| bucket['type'] == 'user' }.each do |bucket|
-        dbrp = @dbrp_hash.find { |dbrp| dbrp['bucketID'] == bucket['id'] }
+        dbrp = @dbrp_hash.find { |d| d['bucketID'] == bucket['id'] }
 
         links_hash = @bucket_hash.find { |b| b['name'] == bucket['name'] }
         bucket_members = links_hash.dig('members', 0, 'users')
@@ -172,8 +172,8 @@ class Puppet::Provider::InfluxdbBucket::InfluxdbBucket < Puppet::ResourceApi::Si
     context.err(e.backtrace)
     nil
   end
-  rescue StandardError => e
-    context.err("Error deleting bucket state: #{e.message}")
-    context.err(e.backtrace)
-    nil
+rescue StandardError => e
+  context.err("Error deleting bucket state: #{e.message}")
+  context.err(e.backtrace)
+  nil
 end

--- a/lib/puppet/provider/influxdb_dbrp/influxdb_dbrp.rb
+++ b/lib/puppet/provider/influxdb_dbrp/influxdb_dbrp.rb
@@ -93,8 +93,8 @@ class Puppet::Provider::InfluxdbDbrp::InfluxdbDbrp < Puppet::ResourceApi::Simple
 
     influx_delete("/api/v2/dbrps/#{id}?org=#{org}")
   end
-  rescue StandardError => e
-    context.err("Error deleting dbrp state: #{e.message}")
-    context.err(e.backtrace)
-    nil
+rescue StandardError => e
+  context.err("Error deleting dbrp state: #{e.message}")
+  context.err(e.backtrace)
+  nil
 end

--- a/lib/puppet/provider/influxdb_dbrp/influxdb_dbrp.rb
+++ b/lib/puppet/provider/influxdb_dbrp/influxdb_dbrp.rb
@@ -27,10 +27,6 @@ class Puppet::Provider::InfluxdbDbrp::InfluxdbDbrp < Puppet::ResourceApi::Simple
     get_org_info if @org_hash.empty?
     get_bucket_info if @bucket_hash.empty?
     get_dbrp_info if @dbrp_hash.empty?
-    init_auth
-    get_org_info
-    get_bucket_info
-    get_dbrp_info
 
     @dbrp_hash.reduce([]) do |memo, value|
       memo + [

--- a/lib/puppet/provider/influxdb_dbrp/influxdb_dbrp.rb
+++ b/lib/puppet/provider/influxdb_dbrp/influxdb_dbrp.rb
@@ -16,6 +16,10 @@ class Puppet::Provider::InfluxdbDbrp::InfluxdbDbrp < Puppet::ResourceApi::Simple
   def canonicalize(_context, resources)
     init_attrs(resources)
     resources
+  rescue StandardError => e
+    context.err("Error canonicalizing resources: #{e.message}")
+    context.err(e.backtrace)
+    nil
   end
 
   def get(_context)
@@ -41,6 +45,10 @@ class Puppet::Provider::InfluxdbDbrp::InfluxdbDbrp < Puppet::ResourceApi::Simple
         },
       ]
     end
+  rescue StandardError => e
+    context.err("Error getting dbrp state: #{e.message}")
+    context.err(e.backtrace)
+    nil
   end
 
   def create(context, name, should)
@@ -54,6 +62,10 @@ class Puppet::Provider::InfluxdbDbrp::InfluxdbDbrp < Puppet::ResourceApi::Simple
       default: should[:is_default],
     }
     influx_post("/api/v2/dbrps?org=#{should[:org]}", JSON.dump(body))
+  rescue StandardError => e
+    context.err("Error creating dbrp state: #{e.message}")
+    context.err(e.backtrace)
+    nil
   end
 
   def update(context, name, should)
@@ -66,6 +78,10 @@ class Puppet::Provider::InfluxdbDbrp::InfluxdbDbrp < Puppet::ResourceApi::Simple
     }
 
     influx_patch("/api/v2/dbrps/#{dbrp_id}?org=#{should[:org]}", JSON.dump(body))
+  rescue StandardError => e
+    context.err("Error updating dbrp state: #{e.message}")
+    context.err(e.backtrace)
+    nil
   end
 
   def delete(context, name)
@@ -77,4 +93,8 @@ class Puppet::Provider::InfluxdbDbrp::InfluxdbDbrp < Puppet::ResourceApi::Simple
 
     influx_delete("/api/v2/dbrps/#{id}?org=#{org}")
   end
+  rescue StandardError => e
+    context.err("Error deleting dbrp state: #{e.message}")
+    context.err(e.backtrace)
+    nil
 end

--- a/lib/puppet/provider/influxdb_dbrp/influxdb_dbrp.rb
+++ b/lib/puppet/provider/influxdb_dbrp/influxdb_dbrp.rb
@@ -23,6 +23,10 @@ class Puppet::Provider::InfluxdbDbrp::InfluxdbDbrp < Puppet::ResourceApi::Simple
   end
 
   def get(_context)
+    init_auth if @auth.empty?
+    get_org_info if @org_hash.empty?
+    get_bucket_info if @bucket_hash.empty?
+    get_dbrp_info if @dbrp_hash.empty?
     init_auth
     get_org_info
     get_bucket_info

--- a/lib/puppet/provider/influxdb_label/influxdb_label.rb
+++ b/lib/puppet/provider/influxdb_label/influxdb_label.rb
@@ -14,6 +14,10 @@ class Puppet::Provider::InfluxdbLabel::InfluxdbLabel < Puppet::ResourceApi::Simp
   def canonicalize(_context, resources)
     init_attrs(resources)
     resources
+  rescue StandardError => e
+    context.err("Error canonicalizing resources: #{e.message}")
+    context.err(e.backtrace)
+    nil
   end
 
   def get(_context)
@@ -39,6 +43,10 @@ class Puppet::Provider::InfluxdbLabel::InfluxdbLabel < Puppet::ResourceApi::Simp
     else
       []
     end
+  rescue StandardError => e
+    context.err("Error getting label state: #{e.message}")
+    context.err(e.backtrace)
+    nil
   end
 
   def create(context, name, should)
@@ -51,6 +59,10 @@ class Puppet::Provider::InfluxdbLabel::InfluxdbLabel < Puppet::ResourceApi::Simp
     }
 
     influx_post('/api/v2/labels', JSON.dump(body))
+  rescue StandardError => e
+    context.err("Error setting label state: #{e.message}")
+    context.err(e.backtrace)
+    nil
   end
 
   def update(context, name, should)
@@ -63,6 +75,10 @@ class Puppet::Provider::InfluxdbLabel::InfluxdbLabel < Puppet::ResourceApi::Simp
     }
 
     influx_patch("/api/v2/labels/#{label_id}", JSON.dump(body))
+  rescue StandardError => e
+    context.err("Error updating label state: #{e.message}")
+    context.err(e.backtrace)
+    nil
   end
 
   def delete(context, name)
@@ -71,4 +87,8 @@ class Puppet::Provider::InfluxdbLabel::InfluxdbLabel < Puppet::ResourceApi::Simp
     label_id = id_from_name(@label_hash, name)
     influx_delete("/api/v2/labels/#{label_id}")
   end
+  rescue StandardError => e
+    context.err("Error deleting label state: #{e.message}")
+    context.err(e.backtrace)
+    nil
 end

--- a/lib/puppet/provider/influxdb_label/influxdb_label.rb
+++ b/lib/puppet/provider/influxdb_label/influxdb_label.rb
@@ -24,14 +24,14 @@ class Puppet::Provider::InfluxdbLabel::InfluxdbLabel < Puppet::ResourceApi::Simp
     init_auth if @auth.empty?
     get_org_info if @org_hash.empty?
     get_label_info if @label_hash.empty?
-    init_auth
-    get_org_info
-    get_label_info
 
-    response = influx_get('/api/v2/labels', params: {})
-    if response['labels']
-      response['labels'].map do |label|
-        {
+    response = influx_get('/api/v2/labels')
+    ret = []
+
+    response.each do |r|
+      next unless r['labels']
+      r['labels'].each do |label|
+        ret << {
           name: label['name'],
           use_ssl: @use_ssl,
           host: @host,
@@ -43,9 +43,9 @@ class Puppet::Provider::InfluxdbLabel::InfluxdbLabel < Puppet::ResourceApi::Simp
           properties: label['properties'],
         }
       end
-    else
-      []
     end
+
+    ret
   rescue StandardError => e
     context.err("Error getting label state: #{e.message}")
     context.err(e.backtrace)

--- a/lib/puppet/provider/influxdb_label/influxdb_label.rb
+++ b/lib/puppet/provider/influxdb_label/influxdb_label.rb
@@ -21,6 +21,9 @@ class Puppet::Provider::InfluxdbLabel::InfluxdbLabel < Puppet::ResourceApi::Simp
   end
 
   def get(_context)
+    init_auth if @auth.empty?
+    get_org_info if @org_hash.empty?
+    get_label_info if @label_hash.empty?
     init_auth
     get_org_info
     get_label_info

--- a/lib/puppet/provider/influxdb_label/influxdb_label.rb
+++ b/lib/puppet/provider/influxdb_label/influxdb_label.rb
@@ -90,8 +90,8 @@ class Puppet::Provider::InfluxdbLabel::InfluxdbLabel < Puppet::ResourceApi::Simp
     label_id = id_from_name(@label_hash, name)
     influx_delete("/api/v2/labels/#{label_id}")
   end
-  rescue StandardError => e
-    context.err("Error deleting label state: #{e.message}")
-    context.err(e.backtrace)
-    nil
+rescue StandardError => e
+  context.err("Error deleting label state: #{e.message}")
+  context.err(e.backtrace)
+  nil
 end

--- a/lib/puppet/provider/influxdb_org/influxdb_org.rb
+++ b/lib/puppet/provider/influxdb_org/influxdb_org.rb
@@ -14,6 +14,10 @@ class Puppet::Provider::InfluxdbOrg::InfluxdbOrg < Puppet::ResourceApi::SimplePr
   def canonicalize(_context, resources)
     init_attrs(resources)
     resources
+  rescue StandardError => e
+    context.err("Error canonicalizing resources: #{e.message}")
+    context.err(e.backtrace)
+    nil
   end
 
   def get(_context)
@@ -49,6 +53,10 @@ class Puppet::Provider::InfluxdbOrg::InfluxdbOrg < Puppet::ResourceApi::SimplePr
         },
       ]
     end
+  rescue StandardError => e
+    context.err("Error getting org state: #{e.message}")
+    context.err(e.backtrace)
+    nil
   end
 
   def create(context, name, should)
@@ -58,6 +66,10 @@ class Puppet::Provider::InfluxdbOrg::InfluxdbOrg < Puppet::ResourceApi::SimplePr
       description: should[:description],
     }
     influx_post('/api/v2/orgs', JSON.dump(body))
+  rescue StandardError => e
+    context.err("Error creating org state: #{e.message}")
+    context.err(e.backtrace)
+    nil
   end
 
   # TODO: make this less ugly
@@ -94,6 +106,10 @@ class Puppet::Provider::InfluxdbOrg::InfluxdbOrg < Puppet::ResourceApi::SimplePr
 
     body = { description: should[:description], }
     influx_patch("/api/v2/orgs/#{org_id}", JSON.dump(body))
+  rescue StandardError => e
+    context.err("Error updating org state: #{e.message}")
+    context.err(e.backtrace)
+    nil
   end
 
   def delete(context, name)
@@ -102,4 +118,8 @@ class Puppet::Provider::InfluxdbOrg::InfluxdbOrg < Puppet::ResourceApi::SimplePr
     id = id_from_name(@org_hash, name)
     influx_delete("/api/v2/orgs/#{id}")
   end
+  rescue StandardError => e
+    context.err("Error deleting org state: #{e.message}")
+    context.err(e.backtrace)
+    nil
 end

--- a/lib/puppet/provider/influxdb_org/influxdb_org.rb
+++ b/lib/puppet/provider/influxdb_org/influxdb_org.rb
@@ -112,8 +112,8 @@ class Puppet::Provider::InfluxdbOrg::InfluxdbOrg < Puppet::ResourceApi::SimplePr
     id = id_from_name(@org_hash, name)
     influx_delete("/api/v2/orgs/#{id}")
   end
-  rescue StandardError => e
-    context.err("Error deleting org state: #{e.message}")
-    context.err(e.backtrace)
-    nil
+rescue StandardError => e
+  context.err("Error deleting org state: #{e.message}")
+  context.err(e.backtrace)
+  nil
 end

--- a/lib/puppet/provider/influxdb_org/influxdb_org.rb
+++ b/lib/puppet/provider/influxdb_org/influxdb_org.rb
@@ -21,6 +21,10 @@ class Puppet::Provider::InfluxdbOrg::InfluxdbOrg < Puppet::ResourceApi::SimplePr
   end
 
   def get(_context)
+    init_auth if @auth.empty?
+    get_org_info if @org_hash.empty?
+    get_user_info if @user_map.empty?
+
     init_auth
     get_org_info
     get_user_info

--- a/lib/puppet/provider/influxdb_setup/influxdb_setup.rb
+++ b/lib/puppet/provider/influxdb_setup/influxdb_setup.rb
@@ -21,7 +21,7 @@ class Puppet::Provider::InfluxdbSetup::InfluxdbSetup < Puppet::ResourceApi::Simp
   end
 
   def get(_context)
-    response = influx_get('/api/v2/setup')
+    response = influx_get('/api/v2/setup')[0]
     [
       {
         name: @host,

--- a/lib/puppet/provider/influxdb_setup/influxdb_setup.rb
+++ b/lib/puppet/provider/influxdb_setup/influxdb_setup.rb
@@ -14,6 +14,10 @@ class Puppet::Provider::InfluxdbSetup::InfluxdbSetup < Puppet::ResourceApi::Simp
   def canonicalize(_context, resources)
     init_attrs(resources)
     resources
+  rescue StandardError => e
+    context.err("Error canonicalizing resources: #{e.message}")
+    context.err(e.backtrace)
+    nil
   end
 
   def get(_context)
@@ -28,6 +32,10 @@ class Puppet::Provider::InfluxdbSetup::InfluxdbSetup < Puppet::ResourceApi::Simp
         ensure: response['allowed'] == true ? 'absent' : 'present',
       },
     ]
+  rescue StandardError => e
+    context.err("Error getting setup state: #{e.message}")
+    context.err(e.backtrace)
+    nil
   end
 
   def create(context, name, should)
@@ -40,6 +48,10 @@ class Puppet::Provider::InfluxdbSetup::InfluxdbSetup < Puppet::ResourceApi::Simp
     }
     response = influx_post('/api/v2/setup', JSON.dump(body))
     File.write(should[:token_file], response['auth']['token'])
+  rescue StandardError => e
+    context.err("Error creating setup state: #{e.message}")
+    context.err(e.backtrace)
+    nil
   end
 
   def update(context, _name, _should)

--- a/lib/puppet/provider/influxdb_user/influxdb_user.rb
+++ b/lib/puppet/provider/influxdb_user/influxdb_user.rb
@@ -14,6 +14,10 @@ class Puppet::Provider::InfluxdbUser::InfluxdbUser < Puppet::ResourceApi::Simple
   def canonicalize(_context, resources)
     init_attrs(resources)
     resources
+  rescue StandardError => e
+    context.err("Error canonicalizing resources: #{e.message}")
+    context.err(e.backtrace)
+    nil
   end
 
   def get(_context)
@@ -47,6 +51,10 @@ class Puppet::Provider::InfluxdbUser::InfluxdbUser < Puppet::ResourceApi::Simple
         },
       ]
     end
+  rescue StandardError => e
+    context.err("Error getting user state: #{e.message}")
+    context.err(e.backtrace)
+    nil
   end
 
   def create(context, name, should)
@@ -58,6 +66,10 @@ class Puppet::Provider::InfluxdbUser::InfluxdbUser < Puppet::ResourceApi::Simple
 
     body = { password: should[:password].unwrap }
     influx_post("/api/v2/users/#{response['id']}/password", JSON.dump(body))
+  rescue StandardError => e
+    context.err("Error creating user state: #{e.message}")
+    context.err(e.backtrace)
+    nil
   end
 
   def update(context, name, should)
@@ -68,6 +80,10 @@ class Puppet::Provider::InfluxdbUser::InfluxdbUser < Puppet::ResourceApi::Simple
       status: should[:status],
     }
     influx_patch("/api/v2/users/#{user_id}", JSON.dump(body))
+  rescue StandardError => e
+    context.err("Error updating user state: #{e.message}")
+    context.err(e.backtrace)
+    nil
   end
 
   def delete(context, name)

--- a/lib/puppet/provider/influxdb_user/influxdb_user.rb
+++ b/lib/puppet/provider/influxdb_user/influxdb_user.rb
@@ -84,8 +84,8 @@ class Puppet::Provider::InfluxdbUser::InfluxdbUser < Puppet::ResourceApi::Simple
     id = id_from_name(@user_map, name)
     influx_delete("/api/v2/users/#{id}")
   end
-  rescue StandardError => e
-    context.err("Error deleting user state: #{e.message}")
-    context.err(e.backtrace)
-    nil
+rescue StandardError => e
+  context.err("Error deleting user state: #{e.message}")
+  context.err(e.backtrace)
+  nil
 end

--- a/lib/puppet/provider/influxdb_user/influxdb_user.rb
+++ b/lib/puppet/provider/influxdb_user/influxdb_user.rb
@@ -21,6 +21,8 @@ class Puppet::Provider::InfluxdbUser::InfluxdbUser < Puppet::ResourceApi::Simple
   end
 
   def get(_context)
+    init_auth if @auth.empty?
+    get_user_info if @user_map.empty?
     init_auth
     get_user_info
 

--- a/lib/puppet_x/puppetlabs/influxdb/influxdb.rb
+++ b/lib/puppet_x/puppetlabs/influxdb/influxdb.rb
@@ -94,9 +94,9 @@ module PuppetX
         []
       end
 
-      #def influx_get(name)
+      # def influx_get(name)
       #  _influx_get(name)
-      #end
+      # end
 
       def influx_post(name, body)
         response = @client.post(URI(@influxdb_uri + name), body, headers: @auth.merge({ 'Content-Type' => 'application/json' }))

--- a/lib/puppet_x/puppetlabs/influxdb/influxdb.rb
+++ b/lib/puppet_x/puppetlabs/influxdb/influxdb.rb
@@ -81,6 +81,10 @@ module PuppetX
         else
           raise Puppet::DevError, "Received HTTP code #{response.code} with message #{response.reason}"
         end
+      rescue StandardError => e
+        Puppet.err("Error in get call: #{e.message}")
+        Puppet.err(e.backtrace)
+        []
       end
 
       def influx_post(name, body)
@@ -135,6 +139,10 @@ module PuppetX
           process_links(org, org['links'])
           @org_hash << org
         end
+      rescue StandardError => e
+        Puppet.err("Error getting org state: #{e.message}")
+        Puppet.err(e.backtrace)
+        nil
       end
 
       def get_bucket_info
@@ -145,6 +153,10 @@ module PuppetX
           process_links(bucket, bucket['links'])
           @bucket_hash << bucket
         end
+      rescue StandardError => e
+        Puppet.err("Error getting bucket state: #{e.message}")
+        Puppet.err(e.backtrace)
+        nil
       end
 
       def get_dbrp_info
@@ -157,6 +169,10 @@ module PuppetX
             @dbrp_hash << dbrp.merge('name' => dbrp['database'])
           end
         end
+      rescue StandardError => e
+        Puppet.err("Error getting dbrp state: #{e.message}")
+        Puppet.err(e.backtrace)
+        nil
       end
 
       def get_telegraf_info
@@ -177,12 +193,20 @@ module PuppetX
           process_links(user, user['links'])
           @user_map << user
         end
+      rescue StandardError => e
+        Puppet.err("Error getting user state: #{e.message}")
+        Puppet.err(e.backtrace)
+        nil
       end
 
       # No links entries for labels other than self
       def get_label_info
         response = influx_get('/api/v2/labels', params: {})
         @label_hash = response['labels'] ? response['labels'] : []
+      rescue StandardError => e
+        Puppet.err("Error getting label state: #{e.message}")
+        Puppet.err(e.backtrace)
+        nil
       end
 
       def process_links(hash, links)
@@ -193,6 +217,10 @@ module PuppetX
           next if (k == 'self') || (k == 'write')
           hash[k] = influx_get(v, params: {})
         end
+      rescue StandardError => e
+        Puppet.err("Error processing links: #{e.message}")
+        Puppet.err(e.backtrace)
+        nil
       end
     end
   end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'pry'
 
 describe 'influxdb' do
   let(:facts) { { os: { family: 'RedHat' }, identity: { user: 'root' } } }

--- a/spec/unit/puppet/provider/influxdb_auth/influxdb_auth_spec.rb
+++ b/spec/unit/puppet/provider/influxdb_auth/influxdb_auth_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Puppet::Provider::InfluxdbAuth::InfluxdbAuth do
   end
 
   let(:org_response) do
-    {
+    [{
       'links' => {
         'self' => '/api/v2/orgs'
       },
@@ -44,11 +44,11 @@ RSpec.describe Puppet::Provider::InfluxdbAuth::InfluxdbAuth do
           },
         },
       ]
-    }
+    }]
   end
 
   let(:auth_response) do
-    {
+    [{
       'links' => {
         'self' => '/api/v2/authorizations'
       },
@@ -74,13 +74,13 @@ RSpec.describe Puppet::Provider::InfluxdbAuth::InfluxdbAuth do
         }
       },
     ]
-    }
+    }]
   end
 
   describe '#get' do
     # rubocop:disable RSpec/SubjectStub
     it 'processes resources' do
-      allow(provider).to receive(:influx_get).with('/api/v2/orgs', params: {}).and_return(org_response)
+      allow(provider).to receive(:influx_get).with('/api/v2/orgs').and_return(org_response)
       provider.instance_variable_set('@use_ssl', true)
       provider.instance_variable_set('@host', 'foo.bar.com')
       provider.instance_variable_set('@port', 8086)
@@ -110,7 +110,7 @@ RSpec.describe Puppet::Provider::InfluxdbAuth::InfluxdbAuth do
         },
       ]
 
-      allow(provider).to receive(:influx_get).with('/api/v2/authorizations', params: {}).and_return(auth_response)
+      allow(provider).to receive(:influx_get).with('/api/v2/authorizations').and_return(auth_response)
       expect(provider.get(context)).to eq should_hash
     end
   end

--- a/spec/unit/puppet/provider/influxdb_bucket/influxdb_bucket_spec.rb
+++ b/spec/unit/puppet/provider/influxdb_bucket/influxdb_bucket_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Puppet::Provider::InfluxdbBucket::InfluxdbBucket do
   end
 
   let(:bucket_response) do
-    {
+    [{
       'links' => {
         'self' => '/api/v2/buckets?descending=false&limit=20&offset=0'
       },
@@ -60,11 +60,11 @@ RSpec.describe Puppet::Provider::InfluxdbBucket::InfluxdbBucket do
           'labels' => { 'links' => { 'self' => '/api/v2/labels' }, 'labels' => [] }
         },
       ]
-    }
+    }]
   end
 
   let(:org_response) do
-    {
+    [{
       'links' => {
         'self' => '/api/v2/orgs'
       },
@@ -77,11 +77,11 @@ RSpec.describe Puppet::Provider::InfluxdbBucket::InfluxdbBucket do
           },
         },
       ]
-    }
+    }]
   end
 
   let(:label_response) do
-    {
+    [{
       'links' => {
         'self' => '/api/v2/labels'
       },
@@ -95,11 +95,11 @@ RSpec.describe Puppet::Provider::InfluxdbBucket::InfluxdbBucket do
           },
         },
       ]
-    }
+    }]
   end
 
   let(:user_response) do
-    {
+    [{
       'links' => {
         'self' => '/api/v2/users'
       },
@@ -113,11 +113,11 @@ RSpec.describe Puppet::Provider::InfluxdbBucket::InfluxdbBucket do
           'status' => 'active'
         },
       ]
-    }
+    }]
   end
 
   let(:dbrp_response) do
-    {
+    [{
       'content' => [
         {
           'id' => '1234567',
@@ -128,7 +128,7 @@ RSpec.describe Puppet::Provider::InfluxdbBucket::InfluxdbBucket do
           'bucketID' => '12345'
         },
       ]
-    }
+    }]
   end
 
   describe '#get' do
@@ -136,11 +136,11 @@ RSpec.describe Puppet::Provider::InfluxdbBucket::InfluxdbBucket do
     context 'with bucket resources' do
       # rubocop:disable RSpec/SubjectStub
       it 'processes resources' do
-        allow(provider).to receive(:influx_get).with('/api/v2/orgs', params: {}).and_return(org_response)
-        allow(provider).to receive(:influx_get).with('/api/v2/buckets', params: {}).and_return(bucket_response)
-        allow(provider).to receive(:influx_get).with('/api/v2/labels', params: {}).and_return(label_response)
-        allow(provider).to receive(:influx_get).with('/api/v2/dbrps?orgID=123', params: {}).and_return(dbrp_response)
-        allow(provider).to receive(:influx_get).with('/api/v2/users', params: {}).and_return(user_response)
+        allow(provider).to receive(:influx_get).with('/api/v2/orgs').and_return(org_response)
+        allow(provider).to receive(:influx_get).with('/api/v2/buckets').and_return(bucket_response)
+        allow(provider).to receive(:influx_get).with('/api/v2/labels').and_return(label_response)
+        allow(provider).to receive(:influx_get).with('/api/v2/dbrps?orgID=123').and_return(dbrp_response)
+        allow(provider).to receive(:influx_get).with('/api/v2/users').and_return(user_response)
 
         provider.instance_variable_set('@use_ssl', true)
         provider.instance_variable_set('@host', 'foo.bar.com')
@@ -166,6 +166,402 @@ RSpec.describe Puppet::Provider::InfluxdbBucket::InfluxdbBucket do
         expect(provider.get(context)).to eq should_hash
       end
     end
+
+    #context 'with paginated api response' do
+    #  it 'processes paginated responses' do
+    #    response_1 = [{
+    #      'links' => {
+    #        'self' => '/api/v2/buckets?descending=false&limit=20&offset=0',
+    #        'next' => '/api/v2/buckets?descending=false&limit=20&offset=20'
+    #      },
+    #      'buckets' => [
+    #          {
+    #            'id' => '1231',
+    #            'orgID' => '123',
+    #            'type' => 'user',
+    #            'name' => '1',
+    #            'links' => {
+    #              'self' => '/api/v2/buckets/1',
+    #            },
+    #            'retentionRules' => [
+    #              {
+    #                'type' => 'expire',
+    #                'everySeconds' => 2_592_000,
+    #                'shardGroupDurationSeconds' => 604_800
+    #              },
+    #            ],
+    #            'labels' => { 'links' => { 'self' => '/api/v2/labels' }, 'labels' => [] }
+    #          },
+    #          {
+    #            'id' => '1232',
+    #            'orgID' => '123',
+    #            'type' => 'user',
+    #            'name' => '2',
+    #            'links' => {
+    #              'self' => '/api/v2/buckets/2',
+    #            },
+    #            'retentionRules' => [
+    #              {
+    #                'type' => 'expire',
+    #                'everySeconds' => 2_592_000,
+    #                'shardGroupDurationSeconds' => 604_800
+    #              },
+    #            ],
+    #            'labels' => { 'links' => { 'self' => '/api/v2/labels' }, 'labels' => [] }
+    #          },
+    #          {
+    #            'id' => '1233',
+    #            'orgID' => '123',
+    #            'type' => 'user',
+    #            'name' => '3',
+    #            'links' => {
+    #              'self' => '/api/v2/buckets/3',
+    #            },
+    #            'retentionRules' => [
+    #              {
+    #                'type' => 'expire',
+    #                'everySeconds' => 2_592_000,
+    #                'shardGroupDurationSeconds' => 604_800
+    #              },
+    #            ],
+    #            'labels' => { 'links' => { 'self' => '/api/v2/labels' }, 'labels' => [] }
+    #          },
+    #          {
+    #            'id' => '1234',
+    #            'orgID' => '123',
+    #            'type' => 'user',
+    #            'name' => '4',
+    #            'links' => {
+    #              'self' => '/api/v2/buckets/4',
+    #            },
+    #            'retentionRules' => [
+    #              {
+    #                'type' => 'expire',
+    #                'everySeconds' => 2_592_000,
+    #                'shardGroupDurationSeconds' => 604_800
+    #              },
+    #            ],
+    #            'labels' => { 'links' => { 'self' => '/api/v2/labels' }, 'labels' => [] }
+    #          },
+    #          {
+    #            'id' => '1235',
+    #            'orgID' => '123',
+    #            'type' => 'user',
+    #            'name' => '5',
+    #            'links' => {
+    #              'self' => '/api/v2/buckets/5',
+    #            },
+    #            'retentionRules' => [
+    #              {
+    #                'type' => 'expire',
+    #                'everySeconds' => 2_592_000,
+    #                'shardGroupDurationSeconds' => 604_800
+    #              },
+    #            ],
+    #            'labels' => { 'links' => { 'self' => '/api/v2/labels' }, 'labels' => [] }
+    #          },
+    #          {
+    #            'id' => '1236',
+    #            'orgID' => '123',
+    #            'type' => 'user',
+    #            'name' => '6',
+    #            'links' => {
+    #              'self' => '/api/v2/buckets/6',
+    #            },
+    #            'retentionRules' => [
+    #              {
+    #                'type' => 'expire',
+    #                'everySeconds' => 2_592_000,
+    #                'shardGroupDurationSeconds' => 604_800
+    #              },
+    #            ],
+    #            'labels' => { 'links' => { 'self' => '/api/v2/labels' }, 'labels' => [] }
+    #          },
+    #          {
+    #            'id' => '1237',
+    #            'orgID' => '123',
+    #            'type' => 'user',
+    #            'name' => '7',
+    #            'links' => {
+    #              'self' => '/api/v2/buckets/7',
+    #            },
+    #            'retentionRules' => [
+    #              {
+    #                'type' => 'expire',
+    #                'everySeconds' => 2_592_000,
+    #                'shardGroupDurationSeconds' => 604_800
+    #              },
+    #            ],
+    #            'labels' => { 'links' => { 'self' => '/api/v2/labels' }, 'labels' => [] }
+    #          },
+    #          {
+    #            'id' => '1238',
+    #            'orgID' => '123',
+    #            'type' => 'user',
+    #            'name' => '8',
+    #            'links' => {
+    #              'self' => '/api/v2/buckets/8',
+    #            },
+    #            'retentionRules' => [
+    #              {
+    #                'type' => 'expire',
+    #                'everySeconds' => 2_592_000,
+    #                'shardGroupDurationSeconds' => 604_800
+    #              },
+    #            ],
+    #            'labels' => { 'links' => { 'self' => '/api/v2/labels' }, 'labels' => [] }
+    #          },
+    #          {
+    #            'id' => '1239',
+    #            'orgID' => '123',
+    #            'type' => 'user',
+    #            'name' => '9',
+    #            'links' => {
+    #              'self' => '/api/v2/buckets/9',
+    #            },
+    #            'retentionRules' => [
+    #              {
+    #                'type' => 'expire',
+    #                'everySeconds' => 2_592_000,
+    #                'shardGroupDurationSeconds' => 604_800
+    #              },
+    #            ],
+    #            'labels' => { 'links' => { 'self' => '/api/v2/labels' }, 'labels' => [] }
+    #          },
+    #          {
+    #            'id' => '12310',
+    #            'orgID' => '123',
+    #            'type' => 'user',
+    #            'name' => '10',
+    #            'links' => {
+    #              'self' => '/api/v2/buckets/10',
+    #            },
+    #            'retentionRules' => [
+    #              {
+    #                'type' => 'expire',
+    #                'everySeconds' => 2_592_000,
+    #                'shardGroupDurationSeconds' => 604_800
+    #              },
+    #            ],
+    #            'labels' => { 'links' => { 'self' => '/api/v2/labels' }, 'labels' => [] }
+    #          },
+    #          {
+    #            'id' => '12311',
+    #            'orgID' => '123',
+    #            'type' => 'user',
+    #            'name' => '11',
+    #            'links' => {
+    #              'self' => '/api/v2/buckets/11',
+    #            },
+    #            'retentionRules' => [
+    #              {
+    #                'type' => 'expire',
+    #                'everySeconds' => 2_592_000,
+    #                'shardGroupDurationSeconds' => 604_800
+    #              },
+    #            ],
+    #            'labels' => { 'links' => { 'self' => '/api/v2/labels' }, 'labels' => [] }
+    #          },
+    #          {
+    #            'id' => '12312',
+    #            'orgID' => '123',
+    #            'type' => 'user',
+    #            'name' => '12',
+    #            'links' => {
+    #              'self' => '/api/v2/buckets/12',
+    #            },
+    #            'retentionRules' => [
+    #              {
+    #                'type' => 'expire',
+    #                'everySeconds' => 2_592_000,
+    #                'shardGroupDurationSeconds' => 604_800
+    #              },
+    #            ],
+    #            'labels' => { 'links' => { 'self' => '/api/v2/labels' }, 'labels' => [] }
+    #          },
+    #          {
+    #            'id' => '12313',
+    #            'orgID' => '123',
+    #            'type' => 'user',
+    #            'name' => '13',
+    #            'links' => {
+    #              'self' => '/api/v2/buckets/13',
+    #            },
+    #            'retentionRules' => [
+    #              {
+    #                'type' => 'expire',
+    #                'everySeconds' => 2_592_000,
+    #                'shardGroupDurationSeconds' => 604_800
+    #              },
+    #            ],
+    #            'labels' => { 'links' => { 'self' => '/api/v2/labels' }, 'labels' => [] }
+    #          },
+    #          {
+    #            'id' => '12314',
+    #            'orgID' => '123',
+    #            'type' => 'user',
+    #            'name' => '14',
+    #            'links' => {
+    #              'self' => '/api/v2/buckets/14',
+    #            },
+    #            'retentionRules' => [
+    #              {
+    #                'type' => 'expire',
+    #                'everySeconds' => 2_592_000,
+    #                'shardGroupDurationSeconds' => 604_800
+    #              },
+    #            ],
+    #            'labels' => { 'links' => { 'self' => '/api/v2/labels' }, 'labels' => [] }
+    #          },
+    #          {
+    #            'id' => '12315',
+    #            'orgID' => '123',
+    #            'type' => 'user',
+    #            'name' => '15',
+    #            'links' => {
+    #              'self' => '/api/v2/buckets/15',
+    #            },
+    #            'retentionRules' => [
+    #              {
+    #                'type' => 'expire',
+    #                'everySeconds' => 2_592_000,
+    #                'shardGroupDurationSeconds' => 604_800
+    #              },
+    #            ],
+    #            'labels' => { 'links' => { 'self' => '/api/v2/labels' }, 'labels' => [] }
+    #          },
+    #          {
+    #            'id' => '12316',
+    #            'orgID' => '123',
+    #            'type' => 'user',
+    #            'name' => '16',
+    #            'links' => {
+    #              'self' => '/api/v2/buckets/16',
+    #            },
+    #            'retentionRules' => [
+    #              {
+    #                'type' => 'expire',
+    #                'everySeconds' => 2_592_000,
+    #                'shardGroupDurationSeconds' => 604_800
+    #              },
+    #            ],
+    #            'labels' => { 'links' => { 'self' => '/api/v2/labels' }, 'labels' => [] }
+    #          },
+    #          {
+    #            'id' => '12317',
+    #            'orgID' => '123',
+    #            'type' => 'user',
+    #            'name' => '17',
+    #            'links' => {
+    #              'self' => '/api/v2/buckets/17',
+    #            },
+    #            'retentionRules' => [
+    #              {
+    #                'type' => 'expire',
+    #                'everySeconds' => 2_592_000,
+    #                'shardGroupDurationSeconds' => 604_800
+    #              },
+    #            ],
+    #            'labels' => { 'links' => { 'self' => '/api/v2/labels' }, 'labels' => [] }
+    #          },
+    #          {
+    #            'id' => '12318',
+    #            'orgID' => '123',
+    #            'type' => 'user',
+    #            'name' => '18',
+    #            'links' => {
+    #              'self' => '/api/v2/buckets/18',
+    #            },
+    #            'retentionRules' => [
+    #              {
+    #                'type' => 'expire',
+    #                'everySeconds' => 2_592_000,
+    #                'shardGroupDurationSeconds' => 604_800
+    #              },
+    #            ],
+    #            'labels' => { 'links' => { 'self' => '/api/v2/labels' }, 'labels' => [] }
+    #          },
+    #          {
+    #            'id' => '12319',
+    #            'orgID' => '123',
+    #            'type' => 'user',
+    #            'name' => '19',
+    #            'links' => {
+    #              'self' => '/api/v2/buckets/19',
+    #            },
+    #            'retentionRules' => [
+    #              {
+    #                'type' => 'expire',
+    #                'everySeconds' => 2_592_000,
+    #                'shardGroupDurationSeconds' => 604_800
+    #              },
+    #            ],
+    #            'labels' => { 'links' => { 'self' => '/api/v2/labels' }, 'labels' => [] }
+    #          },
+    #          {
+    #            'id' => '12320',
+    #            'orgID' => '123',
+    #            'type' => 'user',
+    #            'name' => '20',
+    #            'links' => {
+    #              'self' => '/api/v2/buckets/20',
+    #            },
+    #            'retentionRules' => [
+    #              {
+    #                'type' => 'expire',
+    #                'everySeconds' => 2_592_000,
+    #                'shardGroupDurationSeconds' => 604_800
+    #              },
+    #            ],
+    #            'labels' => { 'links' => { 'self' => '/api/v2/labels' }, 'labels' => [] }
+    #          },
+    #      ]
+    #    }]
+
+    #    response_2 = [{
+    #      'links' => {
+    #        'self' => '/api/v2/buckets?descending=false&limit=20&offset=20',
+    #        'prev' => '/api/v2/buckets?descending=false&limit=20&offset=0'
+    #      },
+    #      'buckets' => [
+    #          {
+    #            'id' => '12321',
+    #            'orgID' => '123',
+    #            'type' => 'user',
+    #            'name' => '21',
+    #            'links' => {
+    #              'self' => '/api/v2/buckets/21',
+    #            },
+    #            'retentionRules' => [
+    #              {
+    #                'type' => 'expire',
+    #                'everySeconds' => 2_592_000,
+    #                'shardGroupDurationSeconds' => 604_800
+    #              },
+    #            ],
+    #            'labels' => { 'links' => { 'self' => '/api/v2/labels' }, 'labels' => [] }
+    #          },
+    #      ]
+    #    }]
+
+    #    allow(provider).to receive(:influx_get).with('/api/v2/orgs').and_return(org_response)
+    #    #allow(provider).to receive(:get_bucket_info)
+    #    allow(provider).to receive(:influx_get).with('/api/v2/buckets').and_return(response_1)
+    #    allow(provider).to receive(:influx_get).with('/api/v2/labels').and_return(label_response)
+    #    allow(provider).to receive(:influx_get).with('/api/v2/dbrps?orgID=123').and_return(dbrp_response)
+    #    allow(provider).to receive(:influx_get).with('/api/v2/users').and_return(user_response)
+
+    #    provider.instance_variable_set('@use_ssl', true)
+    #    provider.instance_variable_set('@host', 'foo.bar.com')
+    #    provider.instance_variable_set('@port', 8086)
+    #    provider.instance_variable_set('@token_file', '/root/.influxdb_token')
+    #    provider.instance_variable_set('@token', RSpec::Puppet::Sensitive.new('puppetlabs'))
+
+    #    expect(provider).to receive(:influx_get).with("/api/v2/buckets")
+    #    expect(provider).to receive(:influx_get).with("/api/v2/buckets?descending=false&limit=20&offset=20")
+    #    provider.get(context)
+    #  end
+    #end
   end
 
   describe '#create' do
@@ -182,7 +578,7 @@ RSpec.describe Puppet::Provider::InfluxdbBucket::InfluxdbBucket do
       provider.instance_variable_set('@org_hash', [{ 'name' => 'puppetlabs', 'id' => 123 }])
       provider.instance_variable_set('@bucket_hash', [{ 'name' => 'puppet_data', 'id' => 12_345 }])
 
-      allow(provider).to receive(:influx_get).with('/api/v2/buckets', params: {}).and_return(bucket_response)
+      allow(provider).to receive(:influx_get).with('/api/v2/buckets').and_return(bucket_response)
       allow(provider).to receive(:influx_post).with(*post_args)
 
       expect(context).to receive(:debug).with("Creating '#{should_hash[:name]}' with #{should_hash.inspect}")
@@ -212,18 +608,18 @@ RSpec.describe Puppet::Provider::InfluxdbBucket::InfluxdbBucket do
             {
               'name' => 'puppet_data',
               'id' => 12_345,
-              'labels' => {
+              'labels' => [{
                 'links' => {
                   'self' => '/api/v2/labels'
                 },
                 'labels' => [],
-                'members' => {
+                'members' => [{
                   'links' => {
                     'self' => '/api/v2/buckets/12345/members'
                   },
                 'users' => []
-                }
-              }
+                }]
+              }]
             },
           ],
         )
@@ -259,18 +655,18 @@ RSpec.describe Puppet::Provider::InfluxdbBucket::InfluxdbBucket do
             {
               'name' => 'puppet_data',
               'id' => 12_345,
-              'labels' => {
+              'labels' => [{
                 'links' => {
                   'self' => '/api/v2/labels'
                 },
                 'labels' => []
-              },
-              'members' => {
+              }],
+              'members' => [{
                 'links' => {
                   'self' => '/api/v2/buckets/12345/members'
                 },
                 'users' => []
-              }
+              }]
             },
           ],
         )
@@ -325,18 +721,18 @@ RSpec.describe Puppet::Provider::InfluxdbBucket::InfluxdbBucket do
             {
               'name' => 'puppet_data',
               'id' => 12_345,
-              'labels' => {
+              'labels' => [{
                 'links' => {
                   'self' => '/api/v2/labels'
                 },
                 'labels' => []
-              },
-              'members' => {
+              }],
+              'members' => [{
                 'links' => {
                   'self' => '/api/v2/buckets/12345/members'
                 },
                 'users' => []
-              }
+              }]
             },
           ],
         )
@@ -347,8 +743,6 @@ RSpec.describe Puppet::Provider::InfluxdbBucket::InfluxdbBucket do
         expect(context).to receive(:warning).with('Could not find label label_1')
         expect(context).to receive(:warning).with('Could not find label label_2')
         expect(provider).to receive(:influx_patch).with(*patch_args)
-        # expect(provider).to receive(:influx_post).with('/api/v2/buckets/12345/members', JSON.dump({id: '4321'}))
-        # expect(provider).to receive(:influx_post).with('/api/v2/buckets/12345/members', JSON.dump({id: '321'}))
 
         provider.update(context, should_hash[:name], should_hash)
       end
@@ -370,18 +764,18 @@ RSpec.describe Puppet::Provider::InfluxdbBucket::InfluxdbBucket do
             {
               'name' => 'puppet_data',
               'id' => 12_345,
-              'labels' => {
+              'labels' => [{
                 'links' => {
                   'self' => '/api/v2/labels'
                 },
                 'labels' => []
-              },
-              'members' => {
+              }],
+              'members' => [{
                 'links' => {
                   'self' => '/api/v2/buckets/12345/members'
                 },
                 'users' => []
-              }
+              }]
             },
           ],
         )

--- a/spec/unit/puppet/provider/influxdb_bucket/influxdb_bucket_spec.rb
+++ b/spec/unit/puppet/provider/influxdb_bucket/influxdb_bucket_spec.rb
@@ -167,7 +167,7 @@ RSpec.describe Puppet::Provider::InfluxdbBucket::InfluxdbBucket do
       end
     end
 
-    #context 'with paginated api response' do
+    # context 'with paginated api response' do
     #  it 'processes paginated responses' do
     #    response_1 = [{
     #      'links' => {
@@ -561,7 +561,7 @@ RSpec.describe Puppet::Provider::InfluxdbBucket::InfluxdbBucket do
     #    expect(provider).to receive(:influx_get).with("/api/v2/buckets?descending=false&limit=20&offset=20")
     #    provider.get(context)
     #  end
-    #end
+    # end
   end
 
   describe '#create' do

--- a/spec/unit/puppet/provider/influxdb_dbrp/influxdb_dbrp_spec.rb
+++ b/spec/unit/puppet/provider/influxdb_dbrp/influxdb_dbrp_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Puppet::Provider::InfluxdbDbrp::InfluxdbDbrp do
   end
 
   let(:bucket_response) do
-    {
+    [{
       'links' => {
         'self' => '/api/v2/buckets?descending=false&limit=20&offset=0'
       },
@@ -57,11 +57,11 @@ RSpec.describe Puppet::Provider::InfluxdbDbrp::InfluxdbDbrp do
           'labels' => { 'links' => { 'self' => '/api/v2/labels' }, 'labels' => [] }
         },
       ]
-    }
+    }]
   end
 
   let(:org_response) do
-    {
+    [{
       'links' => {
         'self' => '/api/v2/orgs'
       },
@@ -74,11 +74,11 @@ RSpec.describe Puppet::Provider::InfluxdbDbrp::InfluxdbDbrp do
           },
         },
       ]
-    }
+    }]
   end
 
   let(:dbrp_response) do
-    {
+    [{
       'content' => [
         {
           'id' => '1234567',
@@ -89,7 +89,7 @@ RSpec.describe Puppet::Provider::InfluxdbDbrp::InfluxdbDbrp do
           'bucketID' => '12345'
         },
       ]
-    }
+    }]
   end
 
   describe '#get' do
@@ -102,9 +102,9 @@ RSpec.describe Puppet::Provider::InfluxdbDbrp::InfluxdbDbrp do
         provider.instance_variable_set('@token_file', '/root/.influxdb_token')
         provider.instance_variable_set('@token', RSpec::Puppet::Sensitive.new('puppetlabs'))
 
-        allow(provider).to receive(:influx_get).with('/api/v2/orgs', params: {}).and_return(org_response)
-        allow(provider).to receive(:influx_get).with('/api/v2/dbrps?orgID=123', params: {}).and_return(dbrp_response)
-        allow(provider).to receive(:influx_get).with('/api/v2/buckets', params: {}).and_return(bucket_response)
+        allow(provider).to receive(:influx_get).with('/api/v2/orgs').and_return(org_response)
+        allow(provider).to receive(:influx_get).with('/api/v2/dbrps?orgID=123').and_return(dbrp_response)
+        allow(provider).to receive(:influx_get).with('/api/v2/buckets').and_return(bucket_response)
 
         should_hash = [{
           bucket: 'puppet_data',

--- a/spec/unit/puppet/provider/influxdb_label/influxdb_label_spec.rb
+++ b/spec/unit/puppet/provider/influxdb_label/influxdb_label_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Puppet::Provider::InfluxdbLabel::InfluxdbLabel do
   end
 
   let(:org_response) do
-    {
+    [{
       'links' => {
         'self' => '/api/v2/orgs'
       },
@@ -41,11 +41,11 @@ RSpec.describe Puppet::Provider::InfluxdbLabel::InfluxdbLabel do
           },
         },
       ]
-    }
+    }]
   end
 
   let(:label_response) do
-    {
+    [{
       'links' => {
         'self' => '/api/v2/labels'
       },
@@ -59,11 +59,11 @@ RSpec.describe Puppet::Provider::InfluxdbLabel::InfluxdbLabel do
           },
         },
       ]
-    }
+    }]
   end
 
   let(:user_response) do
-    {
+    [{
       'links' => {
         'self' => '/api/v2/users'
       },
@@ -77,7 +77,7 @@ RSpec.describe Puppet::Provider::InfluxdbLabel::InfluxdbLabel do
           'status' => 'active'
         },
       ]
-    }
+    }]
   end
 
   describe '#get' do
@@ -89,8 +89,8 @@ RSpec.describe Puppet::Provider::InfluxdbLabel::InfluxdbLabel do
       provider.instance_variable_set('@token_file', '/root/.influxdb_token')
       provider.instance_variable_set('@token', RSpec::Puppet::Sensitive.new('puppetlabs'))
 
-      allow(provider).to receive(:influx_get).with('/api/v2/orgs', params: {}).and_return(org_response)
-      allow(provider).to receive(:influx_get).with('/api/v2/labels', params: {}).and_return(label_response)
+      allow(provider).to receive(:influx_get).with('/api/v2/orgs').and_return(org_response)
+      allow(provider).to receive(:influx_get).with('/api/v2/labels').and_return(label_response)
 
       should_hash = [
         {

--- a/spec/unit/puppet/provider/influxdb_org/influxdb_org_spec.rb
+++ b/spec/unit/puppet/provider/influxdb_org/influxdb_org_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Puppet::Provider::InfluxdbOrg::InfluxdbOrg do
   end
 
   let(:org_response) do
-    {
+    [{
       'links' => {
         'self' => '/api/v2/orgs'
       },
@@ -41,11 +41,11 @@ RSpec.describe Puppet::Provider::InfluxdbOrg::InfluxdbOrg do
           },
         },
       ]
-    }
+    }]
   end
 
   let(:user_response) do
-    {
+    [{
       'links' => {
         'self' => '/api/v2/users'
       },
@@ -59,7 +59,7 @@ RSpec.describe Puppet::Provider::InfluxdbOrg::InfluxdbOrg do
           'status' => 'active'
         },
       ]
-    }
+    }]
   end
 
   describe '#get' do
@@ -71,8 +71,8 @@ RSpec.describe Puppet::Provider::InfluxdbOrg::InfluxdbOrg do
       provider.instance_variable_set('@token_file', '/root/.influxdb_token')
       provider.instance_variable_set('@token', RSpec::Puppet::Sensitive.new('puppetlabs'))
 
-      allow(provider).to receive(:influx_get).with('/api/v2/orgs', params: {}).and_return(org_response)
-      allow(provider).to receive(:influx_get).with('/api/v2/users', params: {}).and_return(user_response)
+      allow(provider).to receive(:influx_get).with('/api/v2/orgs').and_return(org_response)
+      allow(provider).to receive(:influx_get).with('/api/v2/users').and_return(user_response)
 
       should_hash = [
         {

--- a/spec/unit/puppet/provider/influxdb_setup/influxdb_setup_spec.rb
+++ b/spec/unit/puppet/provider/influxdb_setup/influxdb_setup_spec.rb
@@ -27,21 +27,17 @@ RSpec.describe Puppet::Provider::InfluxdbSetup::InfluxdbSetup do
     }
   end
 
-  let(:setup_api_response) do
-    { allowed: true }
-  end
-
   describe '#get' do
     # rubocop:disable RSpec/SubjectStub
     context 'when not setup' do
       it 'processes resources' do
-        allow(provider).to receive(:influx_get).with('/api/v2/setup').and_return({ 'allowed' => true })
+        allow(provider).to receive(:influx_get).with('/api/v2/setup').and_return([{ 'allowed' => true }])
         expect(provider.get(context)[0][:ensure]).to eq 'absent'
       end
 
       context 'when setup' do
         it 'processes resources' do
-          allow(provider).to receive(:influx_get).with('/api/v2/setup').and_return({ 'allowed' => false })
+          allow(provider).to receive(:influx_get).with('/api/v2/setup').and_return([{ 'allowed' => false }])
           expect(provider.get(context)[0][:ensure]).to eq 'present'
         end
       end

--- a/spec/unit/puppet/provider/influxdb_user/influxdb_user_spec.rb
+++ b/spec/unit/puppet/provider/influxdb_user/influxdb_user_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Puppet::Provider::InfluxdbUser::InfluxdbUser do
   end
 
   let(:user_response) do
-    {
+    [{
       'links' => {
         'self' => '/api/v2/users'
       },
@@ -42,7 +42,7 @@ RSpec.describe Puppet::Provider::InfluxdbUser::InfluxdbUser do
           'status' => 'active'
         },
       ]
-    }
+    }]
   end
 
   describe '#get' do
@@ -54,7 +54,7 @@ RSpec.describe Puppet::Provider::InfluxdbUser::InfluxdbUser do
       provider.instance_variable_set('@token_file', '/root/.influxdb_token')
       provider.instance_variable_set('@token', RSpec::Puppet::Sensitive.new('puppetlabs'))
 
-      allow(provider).to receive(:influx_get).with('/api/v2/users', params: {}).and_return(user_response)
+      allow(provider).to receive(:influx_get).with('/api/v2/users').and_return(user_response)
 
       should_hash = [
         {


### PR DESCRIPTION
Prior to this commit, paginated responses from the API were not accounted for.  This created an issue when list operations returned more than the default limit of 20 objects, resulting in some of the resources not being part of the state returned by the get() method.

This commit changes the influx_get() method to handle paginated responses by recursively processing the `next` objects until they are exhausted.