### PR TITLE
(SUP-3397) Do not add/remove the admin user

### DIFF
--- a/lib/puppet/provider/influxdb_org/influxdb_org.rb
+++ b/lib/puppet/provider/influxdb_org/influxdb_org.rb
@@ -78,7 +78,10 @@ class Puppet::Provider::InfluxdbOrg::InfluxdbOrg < Puppet::ResourceApi::SimplePr
     to_add = should_members - cur_members.map { |member| member['name'] }
 
     to_remove.each do |user|
-      next if user == 'admin'
+      if user == 'admin'
+        context.warning('Unable to remove the admin user.  Please remove it from your members[] entry.')
+        next
+      end
 
       user_id = id_from_name(@user_map, user)
       if user_id
@@ -89,6 +92,12 @@ class Puppet::Provider::InfluxdbOrg::InfluxdbOrg < Puppet::ResourceApi::SimplePr
     end
 
     to_add.each do |user|
+      # Admin is already an owner of all orgs
+      if user == 'admin'
+        context.warning('Unable to add the admin user.  Please remove it from your members[] entry.')
+        next
+      end
+
       user_id = id_from_name(@user_map, user)
       if user_id
         body = { name: user, id: user_id }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -83,7 +83,7 @@ class influxdb (
   unless $host == $facts['networking']['fqdn'] or $host == $facts['networking']['hostname'] or $host == 'localhost' {
     fail(
       @("MSG")
-                                Unable to manage InfluxDB installation on host: ${host}.
+                                                Unable to manage InfluxDB installation on host: ${host}.
         Management of repos, packages and services etc is only possible on the local host (${facts['networking']['fqdn']}).
       | MSG
     )

--- a/spec/unit/puppet/provider/influxdb_org/influxdb_org_spec.rb
+++ b/spec/unit/puppet/provider/influxdb_org/influxdb_org_spec.rb
@@ -178,6 +178,27 @@ RSpec.describe Puppet::Provider::InfluxdbOrg::InfluxdbOrg do
       end
     end
 
+    context 'with the admin user' do
+      let(:should_hash) do
+        {
+          name: 'puppetlabs',
+          members: ['admin']
+        }
+      end
+
+      it 'does not add the admin user' do
+        provider.instance_variable_set('@org_hash', [{ 'name' => 'puppetlabs', 'id' => 123 }])
+        patch_args = ['/api/v2/orgs/123', JSON.dump({ description: nil })]
+
+        expect(context).to receive(:debug).with("Updating '#{should_hash[:name]}' with #{should_hash.inspect}")
+        expect(context).to receive(:warning).with('Unable to add the admin user.  Please remove it from your members[] entry.')
+        expect(provider).to receive(:influx_patch).with(*patch_args)
+        expect(provider).not_to receive(:influx_post)
+
+        provider.update(context, should_hash[:name], should_hash)
+      end
+    end
+
     describe '#delete' do
       it 'deletes resources' do
         provider.instance_variable_set('@org_hash', [{ 'name' => 'puppetlabs', 'id' => 123 }])


### PR DESCRIPTION
Prior to this commit, adding the admin user as a member of an org would produce an error, since it cannot be added or removed.  This commit skips it when updating org members