### PR TITLE
toml installation: Support `install_options`

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -7,7 +7,7 @@
 ### Classes
 
 * [`influxdb`](#influxdb): Installs, configures, and performs initial setup of InfluxDB 2.x
-* [`influxdb::profile::toml`](#influxdbprofiletoml): Installs the toml-rb gem inside Puppet server
+* [`influxdb::profile::toml`](#influxdbprofiletoml): Installs the toml-rb gem inside Puppet server and agent
 
 ### Resource types
 
@@ -221,7 +221,7 @@ URL of the GPG signing key
 
 ### <a name="influxdbprofiletoml"></a>`influxdb::profile::toml`
 
-Installs the toml-rb gem inside Puppet server
+Installs the toml-rb gem inside Puppet server and agent
 
 #### Examples
 
@@ -236,6 +236,8 @@ include influxdb::profile::toml
 The following parameters are available in the `influxdb::profile::toml` class:
 
 * [`version`](#version)
+* [`install_options_server`](#install_options_server)
+* [`install_options_agent`](#install_options_agent)
 
 ##### <a name="version"></a>`version`
 
@@ -244,6 +246,22 @@ Data type: `String`
 Version of the toml-rb gem to install
 
 Default value: `'2.1.1'`
+
+##### <a name="install_options_server"></a>`install_options_server`
+
+Data type: `Array[String[1]]`
+
+Pass additional parameters to the puppetserver gem installation
+
+Default value: `[]`
+
+##### <a name="install_options_agent"></a>`install_options_agent`
+
+Data type: `Array[String[1]]`
+
+Pass additional parameters to the puppetserver gem installation
+
+Default value: `[]`
 
 ## Resource types
 

--- a/manifests/profile/toml.pp
+++ b/manifests/profile/toml.pp
@@ -3,8 +3,14 @@
 #   include influxdb::profile::toml
 # @param version
 #   Version of the toml-rb gem to install
+# @param install_options_server
+#   Pass additional parameters to the puppetserver gem installation
+# @param install_options_agent
+#   Pass additional parameters to the puppetserver gem installation
 class influxdb::profile::toml (
   String $version = '2.1.1',
+  Array[String[1]] $install_options_server = [],
+  Array[String[1]] $install_options_agent = [],
 ) {
   $service_name = $facts['pe_server_version'] ? {
     undef   => 'puppetserver',
@@ -12,14 +18,16 @@ class influxdb::profile::toml (
   }
 
   package { 'toml-rb':
-    ensure   => $version,
-    provider => 'puppetserver_gem',
-    notify   => Service[$service_name],
+    ensure          => $version,
+    provider        => 'puppetserver_gem',
+    install_options => $install_options_server,
+    notify          => Service[$service_name],
   }
 
   package { 'toml-rb agent':
-    ensure   => $version,
-    name     => 'toml-rb',
-    provider => 'puppet_gem',
+    ensure          => $version,
+    name            => 'toml-rb',
+    provider        => 'puppet_gem',
+    install_options => $install_options_agent,
   }
 }


### PR DESCRIPTION
This enables people to pass additional parameters to the gem installation for puppet agent/server. A common usecase is a http proxy.