### PR TITLE
(SUP-4215) Add creates param to archive resource

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -177,6 +177,7 @@ class influxdb (
       extract         => true,
       extract_command => 'tar xfz %s --strip-components=1',
       extract_path    => '/opt/influxdb',
+      creates         => '/opt/influxdb/influxd',
       source          => $archive_source,
       cleanup         => true,
       require         => File['/etc/influxdb', '/opt/influxdb'],

--- a/metadata.json
+++ b/metadata.json
@@ -74,7 +74,7 @@
       "version_requirement": ">= 7.0.0 < 9.0.0"
     }
   ],
-  "pdk-version": "2.7.0",
+  "pdk-version": "2.7.1",
   "template-url": "https://github.com/puppetlabs/pdk-templates#main",
-  "template-ref": "heads/main-0-g1ca5ee4"
+  "template-ref": "heads/main-0-gd05508f"
 }


### PR DESCRIPTION
The new version of this module, 6.1.2, includes a fix for ensuring that the cleanup of the archive happens.  However, this introduces an idempotency issue where it will always download and cleanup the archive.