### PR TITLE
(SUP-4274) Swapped legacy fact fqdn for networking.fqdn

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,5 +1,5 @@
 ---
-influxdb::host: "%{facts.fqdn}"
+influxdb::host: "%{facts.networking.fqdn}"
 influxdb::port: 8086
 influxdb::initial_org: 'puppetlabs'
 influxdb::initial_bucket: 'puppet_data'


### PR DESCRIPTION
removed legacy facts for puppet 8 compatibility