### PR TITLE
(SUP-4373-system_store) Add CA bundle option

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
   - [Usage](#usage)
     - [Installation](#installation)
     - [Resource management](#resource-management)
+    - [SSL](#ssl)
   - [Limitations](#limitations)
 - [Supporting Content](#supporting-content)
     - [Articles](#articles)
@@ -191,6 +192,26 @@ class my_profile::my_class{
     }
   )
 ```
+
+### SSL
+
+#### Defaults
+
+The InfluxDB application and Puppet resources can be configured to use SSL.  The [use_ssl](https://forge.puppet.com/modules/puppetlabs/influxdb/reference#use_ssl) parameter of the main class and all resources defaults to `true`, meaning SSL will be used in all communications.  If you wish to disable it, setting `influxdb::use_ssl` to `false` will do so for the application.  Passing `use_ssl` to resources will cause them to query the application without using SSL.
+
+The certificates used in SSL communication default to those issued by the Puppet CA.  The application will use the [ssl certificate](https://forge.puppet.com/modules/puppetlabs/influxdb/reference#ssl_cert_file) and [private key](https://forge.puppet.com/modules/puppetlabs/influxdb/reference#ssl_key_file) used by the Puppet agent on the local machine running InfluxDB.  Applications that query InfluxDB, such as Telegraf and the resources in this module, need to provide a CA certificate issued by the same CA to be trusted.  See the [puppet_operational_dashboards](https://forge.puppet.com/modules/puppetlabs/puppet_operational_dashboards/reference#puppet_operational_dashboardstelegrafagent) module for an example.
+
+#### Configuration
+
+If you wish to manage the certificate files yourself, you can set [manage_ssl](https://forge.puppet.com/modules/puppetlabs/influxdb/reference#manage_ssl).  SSL will still be enabled and used by the resources, but the module will not manage the contents of the certificate files.
+
+If you need to use certificates issued by a CA other than the Puppet CA, you can do so by using either the default OpenSSL CA bundle or by providing your own.  In either case, set the [use_system_store](https://forge.puppet.com/modules/puppetlabs/influxdb/reference#use_system_store) parameter to `true` in the main class and all resources.
+
+Next, either add your CA cert to the default system store or specify a path to the cert using [](https://forge.puppet.com/modules/puppetlabs/influxdb/reference#ca_bundle).
+
+The default location varies by platform, but for example on RedHat, the bundle is located at `/etc/pki/tls/certs/ca-bundle.crt` and your cert can be added to it using the `update-ca-trust` command.  When using this method, the module will use the default location and it isn't necessary to specify `ca_bundle`.
+
+If you wish to save your CA cert to a different location other than the default store, `ca_bundle` to a path containing the cert.
 
 ## Limitations
 

--- a/lib/puppet/functions/influxdb/retrieve_token.rb
+++ b/lib/puppet/functions/influxdb/retrieve_token.rb
@@ -6,30 +6,63 @@ Puppet::Functions.create_function(:'influxdb::retrieve_token') do
     param 'String', :uri
     param 'String', :token_name
     param 'String', :admin_token_file
+    param 'Boolean', :use_system_store
+    optional_param 'String', :ca_bundle
   end
 
   dispatch :retrieve_token do
     param 'String', :uri
     param 'String', :token_name
     param 'Sensitive', :admin_token
+    param 'Boolean', :use_system_store
+    optional_param 'String', :ca_bundle
   end
 
-  def retrieve_token_file(uri, token_name, admin_token_file)
+  def retrieve_token_file(uri, token_name, admin_token_file, use_system_store, ca_bundle = '')
     admin_token = File.read(admin_token_file)
-    retrieve_token(uri, token_name, admin_token)
+    retrieve_token(uri, token_name, admin_token, use_system_store, ca_bundle)
   rescue Errno::EISDIR, Errno::EACCES, Errno::ENOENT => e
     Puppet.err("Unable to retrieve #{token_name}": e.message)
     nil
   end
 
-  def retrieve_token(uri, token_name, admin_token)
+  def retrieve_token(uri, token_name, admin_token, use_system_store, ca_bundle = '')
     if admin_token.is_a?(Puppet::Pops::Types::PSensitiveType::Sensitive)
       admin_token = admin_token.unwrap
     end
 
     client = Puppet.runtime[:http]
-    response = client.get(URI(uri + '/api/v2/authorizations'),
-                           headers: { 'Authorization' => "Token #{admin_token}" })
+    # If using the system store, configure an OpenSSL::X509::Store object to add to the ssl context
+    if use_system_store
+      # Throw an error if a non-existent CA bundle was provided
+      if !ca_bundle.empty? && !File.file?(ca_bundle)
+        Puppet.err("No CA bundle found at #{ca_bundle}")
+        nil
+      end
+    end
+
+    response = if use_system_store
+                 cert_store = OpenSSL::X509::Store.new
+                 # Add the CA bundle to the store object if provided
+                 if !ca_bundle.empty?
+                   cert_store.add_file(ca_bundle)
+                 else
+                   # Otherwise use the default system path
+                   cert_store.set_default_paths
+                 end
+
+                 ssl_context = Puppet::SSL::SSLContext.new(
+                   verify_peer: false,
+                   store: cert_store,
+                 )
+
+                 client_options = { ssl_context: ssl_context }
+                 client.get(URI(uri + '/api/v2/authorizations'),
+                                        headers: { 'Authorization' => "Token #{admin_token}" }, options: client_options)
+               else
+                 client.get(URI(uri + '/api/v2/authorizations'),
+                                        headers: { 'Authorization' => "Token #{admin_token}" })
+               end
 
     if response.success?
       body = JSON.parse(response.body)

--- a/lib/puppet/type/influxdb_auth.rb
+++ b/lib/puppet/type/influxdb_auth.rb
@@ -76,6 +76,18 @@ EOS
       default: true,
       behavior: :parameter,
     },
+    use_system_store: {
+      type: 'Boolean',
+      desc: 'Whether to use the system store for SSL connections',
+      default: false,
+      behavior: :parameter,
+    },
+    ca_bundle: {
+      type: 'String',
+      desc: 'Path to the CA bundle to use if using the system store',
+      default: '',
+      behavior: :parameter,
+    },
     force: {
       type: 'Boolean',
       desc: 'Recreate resource if immutable property changes',

--- a/lib/puppet/type/influxdb_bucket.rb
+++ b/lib/puppet/type/influxdb_bucket.rb
@@ -78,6 +78,18 @@ EOS
       desc: 'Whether to enable SSL for the InfluxDB service',
       default: true,
       behavior: :parameter,
-    }
+    },
+    use_system_store: {
+      type: 'Boolean',
+      desc: 'Whether to use the system store for SSL connections',
+      default: false,
+      behavior: :parameter,
+    },
+    ca_bundle: {
+      type: 'String',
+      desc: 'Path to the CA bundle to use if using the system store',
+      default: '',
+      behavior: :parameter,
+    },
   },
 )

--- a/lib/puppet/type/influxdb_dbrp.rb
+++ b/lib/puppet/type/influxdb_dbrp.rb
@@ -74,6 +74,18 @@ EOS
       desc: 'Whether to enable SSL for the InfluxDB service',
       default: true,
       behavior: :parameter,
-    }
+    },
+    use_system_store: {
+      type: 'Boolean',
+      desc: 'Whether to use the system store for SSL connections',
+      default: false,
+      behavior: :parameter,
+    },
+    ca_bundle: {
+      type: 'String',
+      desc: 'Path to the CA bundle to use if using the system store',
+      default: '',
+      behavior: :parameter,
+    },
   },
 )

--- a/lib/puppet/type/influxdb_label.rb
+++ b/lib/puppet/type/influxdb_label.rb
@@ -58,6 +58,18 @@ EOS
       desc: 'Whether to enable SSL for the InfluxDB service',
       default: true,
       behavior: :parameter,
-    }
+    },
+    use_system_store: {
+      type: 'Boolean',
+      desc: 'Whether to use the system store for SSL connections',
+      default: false,
+      behavior: :parameter,
+    },
+    ca_bundle: {
+      type: 'String',
+      desc: 'Path to the CA bundle to use if using the system store',
+      default: '',
+      behavior: :parameter,
+    },
   },
 )

--- a/lib/puppet/type/influxdb_org.rb
+++ b/lib/puppet/type/influxdb_org.rb
@@ -57,6 +57,18 @@ EOS
       desc: 'Whether to enable SSL for the InfluxDB service',
       default: true,
       behavior: :parameter,
-    }
+    },
+    use_system_store: {
+      type: 'Boolean',
+      desc: 'Whether to use the system store for SSL connections',
+      default: false,
+      behavior: :parameter,
+    },
+    ca_bundle: {
+      type: 'String',
+      desc: 'Path to the CA bundle to use if using the system store',
+      default: '',
+      behavior: :parameter,
+    },
   },
 )

--- a/lib/puppet/type/influxdb_setup.rb
+++ b/lib/puppet/type/influxdb_setup.rb
@@ -74,6 +74,18 @@ EOS
       desc: 'Whether to enable SSL for the InfluxDB service',
       default: true,
       behavior: :parameter,
-    }
+    },
+    use_system_store: {
+      type: 'Boolean',
+      desc: 'Whether to use the system store for SSL connections',
+      default: false,
+      behavior: :parameter,
+    },
+    ca_bundle: {
+      type: 'String',
+      desc: 'Path to the CA bundle to use if using the system store',
+      default: '',
+      behavior: :parameter,
+    },
   },
 )

--- a/lib/puppet/type/influxdb_user.rb
+++ b/lib/puppet/type/influxdb_user.rb
@@ -65,6 +65,18 @@ EOS
       desc: 'Whether to enable SSL for the InfluxDB service',
       default: true,
       behavior: :parameter,
-    }
+    },
+    use_system_store: {
+      type: 'Boolean',
+      desc: 'Whether to use the system store for SSL connections',
+      default: false,
+      behavior: :parameter,
+    },
+    ca_bundle: {
+      type: 'String',
+      desc: 'Path to the CA bundle to use if using the system store',
+      default: '',
+      behavior: :parameter,
+    },
   },
 )

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,6 +21,11 @@
 #   Whether to use http or https connections.  Defaults to true (https).
 # @param manage_ssl
 #   Whether to manage the SSL bundle for https connections.  Defaults to true.
+# @param use_system_store
+#   Whether to use the system store for SSL connections.  Defaults to false.
+# @param ca_bundle
+#   Path to a bundle of CA certificates to use when using the system store.
+#   Defaults to an empty string, which means to use the default system path
 # @param ssl_cert_file
 #   SSL certificate to be used by the influxdb service.  Defaults to the agent certificate issued by the Puppet CA for the local machine.
 # @param ssl_key_file
@@ -68,6 +73,8 @@ class influxdb (
 
   Boolean $use_ssl = true,
   Boolean $manage_ssl = true,
+  Boolean $use_system_store = false,
+  Optional[String] $ca_bundle = undef,
   String  $ssl_cert_file = "/etc/puppetlabs/puppet/ssl/certs/${trusted['certname']}.pem",
   String  $ssl_key_file ="/etc/puppetlabs/puppet/ssl/private_keys/${trusted['certname']}.pem",
   String  $ssl_ca_file ='/etc/puppetlabs/puppet/ssl/certs/ca.pem',
@@ -256,15 +263,17 @@ class influxdb (
 
   if $manage_setup {
     influxdb_setup { $host:
-      ensure     => 'present',
-      port       => $port,
-      use_ssl    => $use_ssl,
-      token_file => $token_file,
-      bucket     => $initial_bucket,
-      org        => $initial_org,
-      username   => $admin_user,
-      password   => $admin_pass,
-      require    => Service['influxdb'],
+      ensure           => 'present',
+      port             => $port,
+      use_ssl          => $use_ssl,
+      use_system_store => $use_system_store,
+      ca_bundle        => $ca_bundle,
+      token_file       => $token_file,
+      bucket           => $initial_bucket,
+      org              => $initial_org,
+      username         => $admin_user,
+      password         => $admin_pass,
+      require          => Service['influxdb'],
     }
   }
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -128,4 +128,21 @@ describe 'influxdb' do
       is_expected.not_to contain_archive('/tmp/influxdb.tar.gz')
     }
   end
+
+  context 'when using the system store' do
+    let(:params) { { host: 'localhost', use_system_store: true, ca_bundle: '' } }
+
+    it {
+      is_expected.to contain_influxdb_setup('localhost').with(
+        ensure: 'present',
+        token_file: '/root/.influxdb_token',
+        bucket: 'puppet_data',
+        org: 'puppetlabs',
+        username: 'admin',
+        password: RSpec::Puppet::Sensitive.new('puppetlabs'),
+        use_system_store: true,
+        ca_bundle: '',
+      )
+    }
+  end
 end

--- a/spec/unit/puppet/provider/influxdb_auth/influxdb_auth_spec.rb
+++ b/spec/unit/puppet/provider/influxdb_auth/influxdb_auth_spec.rb
@@ -52,28 +52,28 @@ RSpec.describe Puppet::Provider::InfluxdbAuth::InfluxdbAuth do
       'links' => {
         'self' => '/api/v2/authorizations'
       },
-    'authorizations' => [
-      {
-        'id' => '123',
-        'user' => 'admin',
-        'token' => '321',
-        'status' => 'active',
-        'description' => 'token_1',
-        'orgID' => '123',
-        'org' => 'puppetlabs',
-        'permissions' => [
-          {
-            'action' => 'read',
-            'resource' => {
-              'type' => 'telegrafs'
-            }
-          },
-        ],
-        'links' => {
-          'self' => '/api/v2/authorizations/123',
-        }
-      },
-    ]
+      'authorizations' => [
+        {
+          'id' => '123',
+          'user' => 'admin',
+          'token' => '321',
+          'status' => 'active',
+          'description' => 'token_1',
+          'orgID' => '123',
+          'org' => 'puppetlabs',
+          'permissions' => [
+            {
+              'action' => 'read',
+              'resource' => {
+                'type' => 'telegrafs'
+              }
+            },
+          ],
+          'links' => {
+            'self' => '/api/v2/authorizations/123',
+          }
+        },
+      ]
     }]
   end
 
@@ -112,6 +112,99 @@ RSpec.describe Puppet::Provider::InfluxdbAuth::InfluxdbAuth do
 
       allow(provider).to receive(:influx_get).with('/api/v2/authorizations').and_return(auth_response)
       expect(provider.get(context)).to eq should_hash
+    end
+
+    context 'when using the system store' do
+      it 'configures and uses the ssl context' do
+        resources = [
+          {
+            ensure: 'present',
+            use_ssl: true,
+            use_system_store: true,
+            host: 'foo.bar.com',
+            port: 8086,
+            token: RSpec::Puppet::Sensitive.new('puppetlabs'),
+            token_file: '/root/.influxdb_token',
+            user: 'admin',
+            name: 'token_1',
+            status: 'active',
+            org: 'puppetlabs',
+            permissions: [
+              {
+                'action' => 'read',
+                'resource' => {
+                  'type' => 'telegrafs'
+                }
+              },
+            ]
+          },
+        ]
+
+        # canonicalize will set up the ssl_context and add it to the @client_options hash
+        provider.canonicalize(context, resources)
+        expect(provider.instance_variable_get('@client_options').key?(:ssl_context)).to eq true
+      end
+
+      it 'checks for a valid CA bundle' do
+        resources = [
+          {
+            ensure: 'present',
+            use_ssl: true,
+            use_system_store: true,
+            ca_bundle: '/not/a/file',
+            host: 'foo.bar.com',
+            port: 8086,
+            token: RSpec::Puppet::Sensitive.new('puppetlabs'),
+            token_file: '/root/.influxdb_token',
+            user: 'admin',
+            name: 'token_1',
+            status: 'active',
+            org: 'puppetlabs',
+            permissions: [
+              {
+                'action' => 'read',
+                'resource' => {
+                  'type' => 'telegrafs'
+                }
+              },
+            ]
+          },
+        ]
+
+        provider.canonicalize(context, resources)
+        expect(instance_variable_get('@logs').any? { |log| log.message == 'No CA bundle found at /not/a/file' }).to eq true
+      end
+    end
+
+    context 'when not using the system store' do
+      it 'does not configure and uses the ssl context' do
+        resources = [
+          {
+            ensure: 'present',
+            use_ssl: true,
+            use_system_store: false,
+            host: 'foo.bar.com',
+            port: 8086,
+            token: RSpec::Puppet::Sensitive.new('puppetlabs'),
+            token_file: '/root/.influxdb_token',
+            user: 'admin',
+            name: 'token_1',
+            status: 'active',
+            org: 'puppetlabs',
+            permissions: [
+              {
+                'action' => 'read',
+                'resource' => {
+                  'type' => 'telegrafs'
+                }
+              },
+            ]
+          },
+        ]
+
+        provider.canonicalize(context, resources)
+        expect(provider.instance_variable_get('@client_options').key?(:ssl_context)).to eq false
+      end
     end
   end
 

--- a/spec/unit/puppet/provider/influxdb_dbrp/influxdb_dbrp_spec.rb
+++ b/spec/unit/puppet/provider/influxdb_dbrp/influxdb_dbrp_spec.rb
@@ -123,6 +123,72 @@ RSpec.describe Puppet::Provider::InfluxdbDbrp::InfluxdbDbrp do
         expect(provider.get(context)).to eq should_hash
       end
     end
+
+    context 'when using the system store' do
+      it 'configures and uses the ssl context' do
+        resources = [{
+          bucket: 'puppet_data',
+          ensure: 'present',
+          use_ssl: true,
+          use_system_store: true,
+          host: 'foo.bar.com',
+          port: 8086,
+          token: RSpec::Puppet::Sensitive.new('puppetlabs'),
+          token_file: '/root/.influxdb_token',
+          is_default: true,
+          name: 'puppet_data',
+          org: 'puppetlabs',
+          rp: 'Forever',
+        }]
+
+        # canonicalize will set up the ssl_context and add it to the @client_options hash
+        provider.canonicalize(context, resources)
+        expect(provider.instance_variable_get('@client_options').key?(:ssl_context)).to eq true
+      end
+
+      it 'checks for a valid CA bundle' do
+        resources = [{
+          bucket: 'puppet_data',
+          ensure: 'present',
+          use_ssl: true,
+          use_system_store: true,
+          ca_bundle: '/not/a/file',
+          host: 'foo.bar.com',
+          port: 8086,
+          token: RSpec::Puppet::Sensitive.new('puppetlabs'),
+          token_file: '/root/.influxdb_token',
+          is_default: true,
+          name: 'puppet_data',
+          org: 'puppetlabs',
+          rp: 'Forever',
+        }]
+
+        provider.canonicalize(context, resources)
+        expect(instance_variable_get('@logs').any? { |log| log.message == 'No CA bundle found at /not/a/file' }).to eq true
+      end
+    end
+
+    context 'when not using the system store' do
+      it 'does not configure and uses the ssl context' do
+        resources = [{
+          bucket: 'puppet_data',
+          ensure: 'present',
+          use_ssl: true,
+          use_system_store: false,
+          host: 'foo.bar.com',
+          port: 8086,
+          token: RSpec::Puppet::Sensitive.new('puppetlabs'),
+          token_file: '/root/.influxdb_token',
+          is_default: true,
+          name: 'puppet_data',
+          org: 'puppetlabs',
+          rp: 'Forever',
+        }]
+
+        provider.canonicalize(context, resources)
+        expect(provider.instance_variable_get('@client_options').key?(:ssl_context)).to eq false
+      end
+    end
   end
 
   describe '#create' do

--- a/spec/unit/puppet/provider/influxdb_label/influxdb_label_spec.rb
+++ b/spec/unit/puppet/provider/influxdb_label/influxdb_label_spec.rb
@@ -108,6 +108,73 @@ RSpec.describe Puppet::Provider::InfluxdbLabel::InfluxdbLabel do
 
       expect(provider.get(context)).to eq should_hash
     end
+
+    context 'when using the system store' do
+      it 'configures and uses the ssl context' do
+        resources = [
+          {
+            name: 'puppetlabs/influxdb',
+            ensure: 'present',
+            use_ssl: true,
+            use_system_store: true,
+            host: 'foo.bar.com',
+            port: 8086,
+            token: RSpec::Puppet::Sensitive.new('puppetlabs'),
+            token_file: '/root/.influxdb_token',
+            org: 'puppetlabs',
+            properties: nil,
+          },
+        ]
+
+        # canonicalize will set up the ssl_context and add it to the @client_options hash
+        provider.canonicalize(context, resources)
+        expect(provider.instance_variable_get('@client_options').key?(:ssl_context)).to eq true
+      end
+
+      it 'checks for a valid CA bundle' do
+        resources = [
+          {
+            name: 'puppetlabs/influxdb',
+            ensure: 'present',
+            use_ssl: true,
+            use_system_store: true,
+            ca_bundle: '/not/a/file',
+            host: 'foo.bar.com',
+            port: 8086,
+            token: RSpec::Puppet::Sensitive.new('puppetlabs'),
+            token_file: '/root/.influxdb_token',
+            org: 'puppetlabs',
+            properties: nil,
+          },
+        ]
+
+        provider.canonicalize(context, resources)
+        expect(instance_variable_get('@logs').any? { |log| log.message == 'No CA bundle found at /not/a/file' }).to eq true
+      end
+    end
+
+    context 'when not using the system store' do
+      it 'does not configure and uses the ssl context' do
+        resources = [
+          {
+            name: 'puppetlabs/influxdb',
+            ensure: 'present',
+            use_ssl: true,
+            use_system_store: false,
+            ca_bundle: '/not/a/file',
+            host: 'foo.bar.com',
+            port: 8086,
+            token: RSpec::Puppet::Sensitive.new('puppetlabs'),
+            token_file: '/root/.influxdb_token',
+            org: 'puppetlabs',
+            properties: nil,
+          },
+        ]
+
+        provider.canonicalize(context, resources)
+        expect(provider.instance_variable_get('@client_options').key?(:ssl_context)).to eq false
+      end
+    end
   end
 
   describe '#create' do


### PR DESCRIPTION
This commit adds the option to use certificates other than those issued by the Puppet CA for making api calls to InfluxDB.  Setting `use_system_store` to `true` will use the CA bundle from the default system store depending on platform.  Setting `ca_bundle` in addition to `use_system_store` will use the specified CA bundle.