### PR TITLE
(#108) influx_auth: fix creation using resource name

### DIFF
--- a/lib/puppet/provider/influxdb_auth/influxdb_auth.rb
+++ b/lib/puppet/provider/influxdb_auth/influxdb_auth.rb
@@ -71,9 +71,9 @@ class Puppet::Provider::InfluxdbAuth::InfluxdbAuth < Puppet::ResourceApi::Simple
       if p['resource'].key?('name') && !p['resource'].key?('id')
         resname = p['resource']['name']
         restype = p['resource']['type']
-        response = influx_get("/api/v2/#{restype}", params: { 'name': resname })
-        if response.key?(restype)
-          p['resource']['id'] = response[restype][0]['id']
+        response = influx_get("/api/v2/#{restype}?name=#{resname}&orgID=#{id_from_name(@org_hash, should[:org])}")
+        if !response.empty? && response[0].key?(restype)
+          p['resource']['id'] = response[0][restype][0]['id']
         else
           context.error("failed to find id for #{restype} #{resname}")
         end


### PR DESCRIPTION
`influx_get` doesn't support params since c195e50.

This feels like a candidate for an additional test creating tokens with a resource name referenced, however I'm not familiar with the test framework so I'm creating this PR without.