### PR TITLE
(maint) Lazy-init host and token_file in PuppetlabsInfluxdb

### DIFF
--- a/lib/puppet_x/puppetlabs/influxdb/influxdb.rb
+++ b/lib/puppet_x/puppetlabs/influxdb/influxdb.rb
@@ -18,7 +18,10 @@ module PuppetX
         end
 
         def token_file
-          @token_file ||= (Facter.value('identity')['user'] == 'root' ? '/root/.influxdb_token' : "/home/#{Facter.value('identity')['user']}/.influxdb_token")
+          return @token_file if @token_file
+
+          user = Facter.value('identity')['user']
+          @token_file = (user == 'root') ? '/root/.influxdb_token' : "/home/#{user}/.influxdb_token"
         end
       end
 

--- a/lib/puppet_x/puppetlabs/influxdb/influxdb.rb
+++ b/lib/puppet_x/puppetlabs/influxdb/influxdb.rb
@@ -8,18 +8,23 @@ module PuppetX
     # Mixin module to provide constants and instance methods for the providers
     module PuppetlabsInfluxdb
       class << self
-        attr_accessor :host, :port, :token_file, :use_ssl, :use_system_store, :cert_store, :ssl_context, :client_options
+        attr_accessor :port, :use_ssl, :use_system_store, :cert_store, :ssl_context, :client_options
+        attr_writer :host, :token_file
+
+        # Lazy so Facter doesn't run at module-load time (breaks test harnesses
+        # where facts aren't yet populated).
+        def host
+          @host ||= Facter.value(:networking)['fqdn']
+        end
+
+        def token_file
+          @token_file ||= (Facter.value('identity')['user'] == 'root' ? '/root/.influxdb_token' : "/home/#{Facter.value('identity')['user']}/.influxdb_token")
+        end
       end
 
-      self.host = Facter.value(:networking)['fqdn']
       self.port = 8086
       self.use_ssl = true
       self.use_system_store = false
-      self.token_file = if Facter.value('identity')['user'] == 'root'
-                          '/root/.influxdb_token'
-                        else
-                          "/home/#{Facter.value('identity')['user']}/.influxdb_token"
-                        end
 
       attr_accessor :telegraf_hash, :user_map, :label_hash, :auth, :bucket_hash, :dbrp_hash
 


### PR DESCRIPTION
## Summary

- Defer `Facter.value(:networking)['fqdn']` and `Facter.value('identity')['user']` (which set the default `host` and `token_file` for the providers) from module-load time to first read.
- Without this, requiring `lib/puppet_x/puppetlabs/influxdb/influxdb.rb` raises `NoMethodError: undefined method '[]' for nil` whenever Facter hasn't been populated yet — which is exactly the case under rspec. That blocked every spec under `spec/unit/puppet/provider/**` from loading at all.
- Lazy class-level readers (`self.host`, `self.token_file`) compute the default on first access. By that point Facter is populated in both the agent runtime and test contexts, so production behavior is identical.

## Test plan

- [x] `bundle exec rspec spec/classes spec/defines spec/functions spec/hosts` — 83 examples, 0 failures, 95% rspec-puppet resource coverage (unchanged from before).
- [x] `bundle exec rspec spec/unit` — 52 examples, 0 failures. Previously these specs would not even load due to the load-time Facter call.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)