### PR TITLE
(maint) Add acceptance coverage for InfluxDB resource types

### DIFF
--- a/spec/acceptance/resource_management_spec.rb
+++ b/spec/acceptance/resource_management_spec.rb
@@ -1,0 +1,134 @@
+require 'spec_helper_acceptance'
+
+# Exercises the InfluxDB resource types (org, bucket, label, user, auth) end to
+# end against a running instance. The module's initial setup writes an admin
+# token to /root/.influxdb_token, which the resources pick up automatically when
+# no explicit token is supplied. Verification is done by querying the InfluxDB
+# 2.x HTTP API directly so we assert on real server state rather than the
+# catalog. SSL is enabled by default (Puppet CA certs), so the API is queried
+# over HTTPS with -k.
+describe 'influxdb resource management' do
+  # Query a path under /api/v2 using the admin token saved by the module.
+  def influx_api(path)
+    run_shell(%(curl -sk -H "Authorization: Token $(cat /root/.influxdb_token)" https://localhost:8086/api/v2/#{path})).stdout
+  end
+
+  context 'when creating resources' do
+    pp = <<-MANIFEST
+      include influxdb
+
+      influxdb_org { 'acceptance_org':
+        ensure      => present,
+        description => 'Org created by acceptance tests',
+      }
+
+      influxdb_label { 'acceptance_label':
+        ensure  => present,
+        org     => 'acceptance_org',
+        require => Influxdb_org['acceptance_org'],
+      }
+
+      influxdb_bucket { 'acceptance_bucket':
+        ensure          => present,
+        org             => 'acceptance_org',
+        labels          => ['acceptance_label'],
+        retention_rules => [{
+          'type'                      => 'expire',
+          'everySeconds'              => 2592000,
+          'shardGroupDurationSeconds' => 604800,
+        }],
+        require         => Influxdb_org['acceptance_org'],
+      }
+
+      # NOTE: password is intentionally omitted. It is an init_only attribute
+      # and the InfluxDB API never returns it, so setting it here makes every
+      # subsequent apply non-idempotent (the type documents that passwords must
+      # be set manually after creation).
+      influxdb_user { 'acceptance_user':
+        ensure => present,
+      }
+
+      influxdb_auth { 'acceptance read token':
+        ensure      => present,
+        org         => 'acceptance_org',
+        permissions => [
+          {
+            'action'   => 'read',
+            'resource' => { 'type' => 'buckets' },
+          },
+        ],
+        require     => Influxdb_org['acceptance_org'],
+      }
+    MANIFEST
+
+    it 'applies idempotently' do
+      idempotent_apply(pp)
+    end
+
+    it 'creates the organization' do
+      expect(influx_api('orgs')).to match(%r{acceptance_org})
+    end
+
+    it 'creates the bucket with its label' do
+      buckets = influx_api('buckets')
+      expect(buckets).to match(%r{acceptance_bucket})
+      expect(influx_api('labels')).to match(%r{acceptance_label})
+    end
+
+    it 'creates the user' do
+      expect(influx_api('users')).to match(%r{acceptance_user})
+    end
+
+    it 'creates the authorization token' do
+      expect(influx_api('authorizations')).to match(%r{acceptance read token})
+    end
+  end
+
+  context 'when removing resources' do
+    pp = <<-MANIFEST
+      include influxdb
+
+      influxdb_auth { 'acceptance read token':
+        ensure      => absent,
+        org         => 'acceptance_org',
+        permissions => [
+          { 'action' => 'read', 'resource' => { 'type' => 'buckets' } },
+        ],
+      }
+
+      influxdb_bucket { 'acceptance_bucket':
+        ensure => absent,
+        org    => 'acceptance_org',
+      }
+
+      influxdb_label { 'acceptance_label':
+        ensure => absent,
+        org    => 'acceptance_org',
+      }
+
+      influxdb_user { 'acceptance_user':
+        ensure => absent,
+      }
+
+      influxdb_org { 'acceptance_org':
+        ensure => absent,
+      }
+    MANIFEST
+
+    it 'applies idempotently' do
+      idempotent_apply(pp)
+    end
+
+    it 'removes the bucket' do
+      expect(influx_api('buckets')).not_to match(%r{acceptance_bucket})
+    end
+
+    it 'removes the user' do
+      expect(influx_api('users')).not_to match(%r{acceptance_user})
+    end
+
+    it 'removes the organization' do
+      expect(influx_api('orgs')).not_to match(%r{acceptance_org})
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds end-to-end acceptance coverage for the module's custom resource types. Until now the only acceptance test installed InfluxDB and checked the service was listening — the resource types (the bulk of the module's value) were untested in acceptance.

New spec: `spec/acceptance/resource_management_spec.rb`

**Creating resources** — applies a manifest with `influxdb_org`, `influxdb_label`, `influxdb_bucket` (with a label and a custom retention rule), `influxdb_user`, and `influxdb_auth` (a read token), then:
- asserts the manifest applies idempotently
- verifies each resource against the live InfluxDB 2.x HTTP API (`/api/v2/orgs|buckets|labels|users|authorizations`) using the admin token the module writes to `/root/.influxdb_token` — so it checks real server state, not just the catalog

**Removing resources** — flips everything to `ensure => absent`, asserts idempotency, and confirms the org/bucket/user are gone from the API.

Reuses the existing litmus helpers (`idempotent_apply`, `run_shell`) and matches the style of `install_spec.rb`. `pdk validate ruby` passes clean.

## Stacked on #130

This is based on `maint/modernise-ci-os-matrix` (#130) so it runs against the reduced, green PE-primary matrix. **Merge #130 first**; GitHub will then retarget this PR to `main`.

## Possible follow-ups (not included)
- `influxdb_dbrp` (database/retention-policy mapping)
- an SSL-disabled (`influxdb::use_ssl: false`) variant
- org membership (`members =>`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
